### PR TITLE
FEATURE: set collapsed css class on body

### DIFF
--- a/src/components/ui.js
+++ b/src/components/ui.js
@@ -88,7 +88,9 @@ export default class InspectorUI extends Component {
 	render() {
 		if ( this.state.isCollapsed ) {
 			document.body.classList.remove( 'ck-inspector-body-expanded' );
+			document.body.classList.add( 'ck-inspector-body-collapsed' );
 		} else {
+			document.body.classList.remove( 'ck-inspector-body-collapsed' );
 			document.body.classList.add( 'ck-inspector-body-expanded' );
 		}
 
@@ -130,6 +132,11 @@ export default class InspectorUI extends Component {
 				<CommandsPane label="Commands" editor={currentEditorInstance} />
 			</Tabs>
 		</Rnd>;
+	}
+	
+	componentWillUnmount() {
+			document.body.classList.remove( 'ck-inspector-body-expanded' );
+			document.body.classList.remove( 'ck-inspector-body-collapsed' );
 	}
 
 	static getDerivedStateFromProps( props, state ) {

--- a/tests/inspector/components/ui.js
+++ b/tests/inspector/components/ui.js
@@ -148,10 +148,12 @@ describe( '<InspectorUI />', () => {
 			const instance = wrapper.instance();
 
 			expect( document.body.classList.contains( 'ck-inspector-body-expanded' ) ).to.be.true;
+			expect( document.body.classList.contains( 'ck-inspector-body-collapsed' ) ).to.be.false;
 
 			instance.setState( { isCollapsed: true } );
 
 			expect( document.body.classList.contains( 'ck-inspector-body-expanded' ) ).to.be.false;
+			expect( document.body.classList.contains( 'ck-inspector-body-collapsed' ) ).to.be.true;
 		} );
 
 		describe( 'resizable container', () => {


### PR DESCRIPTION
This is helpful for being able to adjust the custom UI (in this case Neos CMS),
depending on the three states:

- Inspector not attached at all
- Inspector attached but closed
- Inspector attached and open