### PR TITLE
Checkboxes in the inspector UI should be centered vertically

### DIFF
--- a/src/components/button.js
+++ b/src/components/button.js
@@ -5,6 +5,7 @@
 
 import React, { Component } from 'react';
 import './button.css';
+
 export default class Button extends Component {
 	render() {
 		return <button

--- a/src/components/checkbox.css
+++ b/src/components/checkbox.css
@@ -1,0 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+.ck-inspector .ck-inspector-checkbox {
+	vertical-align: middle;
+}

--- a/src/components/checkbox.js
+++ b/src/components/checkbox.js
@@ -9,13 +9,13 @@ import './checkbox.css';
 export default class Checkbox extends Component {
 	render() {
 		return [
-			<label htmlFor={this.props.id} key="label">{this.props.label}:</label>,
 			<input type="checkbox"
 				className="ck-inspector-checkbox"
 				id={this.props.id}
 				key="input"
 				checked={this.props.isChecked}
-				onChange={this.props.onChange} />
+				onChange={this.props.onChange} />,
+			<label htmlFor={this.props.id} key="label">{this.props.label}</label>
 		];
 	}
 }

--- a/src/components/checkbox.js
+++ b/src/components/checkbox.js
@@ -4,12 +4,15 @@
  */
 
 import React, { Component } from 'react';
+import './checkbox.css';
 
 export default class Checkbox extends Component {
 	render() {
 		return [
 			<label htmlFor={this.props.id} key="label">{this.props.label}:</label>,
-			<input type="checkbox" id={this.props.id}
+			<input type="checkbox"
+				className="ck-inspector-checkbox"
+				id={this.props.id}
 				key="input"
 				checked={this.props.isChecked}
 				onChange={this.props.onChange} />

--- a/src/components/pane.css
+++ b/src/components/pane.css
@@ -45,11 +45,10 @@
 				& + .ck-inspector-tree__config {
 					&::before {
 						content: "";
-						border-right: 1px solid #999;
+						border-right: 1px solid var(--ck-inspector-color-border);
 						display: inline-block;
 						width: 0px;
 						height: 20px;
-						opacity: .5;
 						margin: 0 1em;
 						vertical-align: middle;
 					}

--- a/src/components/pane.css
+++ b/src/components/pane.css
@@ -41,9 +41,27 @@
 				align-items: center;
 			}
 
-			& .ck-inspector-tree__config label {
-				margin-left: 1em;
-				margin-right: 1em;
+			& .ck-inspector-tree__config {
+				& + .ck-inspector-tree__config {
+					&::before {
+						content: "";
+						border-right: 1px solid #999;
+						display: inline-block;
+						width: 0px;
+						height: 20px;
+						opacity: .5;
+						margin: 0 1em;
+						vertical-align: middle;
+					}
+				}
+
+				& label {
+					margin: 0 .5em;
+				}
+
+				& input + label {
+					margin-right: 1em;
+				}
 			}
 		}
 	}

--- a/src/ui.css
+++ b/src/ui.css
@@ -95,7 +95,7 @@
 	margin-right: 1em;
 
 	& select {
-		margin-left: 1em;
+		margin-left: .5em;
 	}
 }
 


### PR DESCRIPTION
Fix: Checkboxes in the inspector UI should be centered vertically. Closes #84.