### PR TITLE
87: Toggle inspector on global ALT+F12 shortcut.

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -180,5 +180,5 @@ function updateBodyHeight( height ) {
 }
 
 function isToggleShortcut( event ) {
-	return event.altKey && event.key === 'F12';
+	return event.altKey && !event.shiftKey && !event.ctrlKey && event.key === 'F12';
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global document */
+/* global document, window */
 
 import React, { Component } from 'react';
 import { Rnd } from 'react-rnd';
@@ -118,17 +118,37 @@ export class DocsButton extends Component {
 }
 
 class ToggleButtonVisual extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.handleShortcut = this.handleShortcut.bind( this );
+	}
+
 	render() {
 		return <button
 			type="button"
 			onClick={this.props.toggleIsCollapsed}
-			title="Toggle inspector"
+			title="Toggle inspector (Alt+F12)"
 			className={[
 				'ck-inspector-navbox__navigation__toggle',
 				this.props.isCollapsed ? ' ck-inspector-navbox__navigation__toggle_up' : ''
 			].join( ' ' )}>
 				Toggle inspector
 		</button>;
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'keydown', this.handleShortcut );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'keydown', this.handleShortcut );
+	}
+
+	handleShortcut( event ) {
+		if ( isToggleShortcut( event ) ) {
+			this.props.toggleIsCollapsed();
+		}
 	}
 }
 
@@ -157,4 +177,8 @@ export const EditorInstanceSelector = connect(
 
 function updateBodyHeight( height ) {
 	document.body.style.setProperty( '--ck-inspector-height', height );
+}
+
+function isToggleShortcut( event ) {
+	return event.altKey && event.key === 'F12';
 }

--- a/tests/inspector/ui.js
+++ b/tests/inspector/ui.js
@@ -16,7 +16,8 @@ import TestEditor from '../utils/testeditor';
 
 import {
 	SET_HEIGHT,
-	SET_CURRENT_EDITOR_NAME
+	SET_CURRENT_EDITOR_NAME,
+	TOGGLE_IS_COLLAPSED
 } from '../../src/data/actions';
 
 describe( '<InspectorUI />', () => {
@@ -336,7 +337,8 @@ describe( '<InspectorUI />', () => {
 						const toggle = getToggle();
 						const button = toggle.find( 'button' );
 
-						expect( toggle.props().onClick ).to.equal( wrapper.props().toggleIsCollapsed );
+						expect( toggle.props().toggleIsCollapsed ).to.be.a( 'function' );
+						expect( button.props().onClick ).to.equal( toggle.props().toggleIsCollapsed );
 						expect( button ).to.not.have.className( 'ck-inspector-navbox__navigation__toggle_up' );
 
 						store.dispatch( {
@@ -352,14 +354,11 @@ describe( '<InspectorUI />', () => {
 					} );
 
 					it( 'should toggle the UI on a global ALT+F12 keyboard shortcut', () => {
-						const toggle = getToggle();
-						const button = toggle.find( 'button' );
-
-						expect( button ).to.not.have.className( 'ck-inspector-navbox__navigation__toggle_up' );
-
 						windowEventMap.keydown( { key: 'F12', altKey: true } );
 
-						expect( getToggle().find( 'button' ) ).to.have.className( 'ck-inspector-navbox__navigation__toggle_up' );
+						sinon.assert.calledWithExactly( dispatchSpy.lastCall, {
+							type: TOGGLE_IS_COLLAPSED
+						} );
 					} );
 				} );
 			} );

--- a/tests/inspector/ui.js
+++ b/tests/inspector/ui.js
@@ -22,6 +22,8 @@ import {
 describe( '<InspectorUI />', () => {
 	let editors, wrapper, store, editor1Element, editor2Element, dispatchSpy;
 
+	const origAddEventListener = window.addEventListener;
+	const windowEventMap = {};
 	const container = document.createElement( 'div' );
 	document.body.appendChild( container );
 
@@ -33,6 +35,12 @@ describe( '<InspectorUI />', () => {
 
 		document.body.appendChild( editor1Element );
 		document.body.appendChild( editor2Element );
+
+		window.addEventListener = ( event, cb ) => {
+			windowEventMap[ event ] = cb;
+
+			origAddEventListener( event, cb );
+		};
 
 		return Promise.all( [
 			TestEditor.create( editor1Element ),
@@ -73,6 +81,8 @@ describe( '<InspectorUI />', () => {
 
 		editor1Element.remove();
 		editor2Element.remove();
+
+		window.addEventListener = origAddEventListener;
 
 		return Promise.all( Array.from( editors )
 			.map( ( [ , editor ] ) => editor.destroy() ) );
@@ -337,6 +347,17 @@ describe( '<InspectorUI />', () => {
 								}
 							}
 						} );
+
+						expect( getToggle().find( 'button' ) ).to.have.className( 'ck-inspector-navbox__navigation__toggle_up' );
+					} );
+
+					it( 'should toggle the UI on a global ALT+F12 keyboard shortcut', () => {
+						const toggle = getToggle();
+						const button = toggle.find( 'button' );
+
+						expect( button ).to.not.have.className( 'ck-inspector-navbox__navigation__toggle_up' );
+
+						windowEventMap.keydown( { key: 'F12', altKey: true } );
 
 						expect( getToggle().find( 'button' ) ).to.have.className( 'ck-inspector-navbox__navigation__toggle_up' );
 					} );

--- a/tests/inspector/ui.js
+++ b/tests/inspector/ui.js
@@ -360,6 +360,18 @@ describe( '<InspectorUI />', () => {
 							type: TOGGLE_IS_COLLAPSED
 						} );
 					} );
+
+					it( 'should not toggle the UI on a global SHIFT+ALT+F12 keyboard shortcut', () => {
+						windowEventMap.keydown( { key: 'F12', altKey: true, shiftKey: true } );
+
+						sinon.assert.notCalled( dispatchSpy );
+					} );
+
+					it( 'should not toggle the UI on a global CTRL+ALT+F12 keyboard shortcut', () => {
+						windowEventMap.keydown( { key: 'F12', altKey: true, ctrlKey: true } );
+
+						sinon.assert.notCalled( dispatchSpy );
+					} );
 				} );
 			} );
 


### PR DESCRIPTION
So I've implemented the toggling as you proposed in the issue - that was easy.

However, I have problem with tests, see f6f1a3a. In here I've added a home made `window.addEventListener()` interceptor, similarly to a one proposed [here](https://github.com/enzymejs/enzyme/issues/426).

However, the test fails on assertion (the code is executed though).

---

Feature: Toggle inspector on Alt+F12 keyboard shortcut. Closes #87.