### PR TITLE
#97: Node attributes should be sorted in trees and node inspectors

### DIFF
--- a/src/model/data/utils.js
+++ b/src/model/data/utils.js
@@ -162,9 +162,10 @@ export function getEditorModelNodeDefinition( currentEditor, node ) {
 
 	definition.properties.path = { value: getNodePathString( node ) };
 
-	for ( const [ name, value ] of node.getAttributes() ) {
-		definition.attributes[ name ] = { value };
-	}
+	getSortedNodeAttributes( node )
+		.forEach( ( [ name, value ] ) => {
+			definition.attributes[ name ] = { value };
+		} );
 
 	definition.properties = stringifyPropertyList( definition.properties );
 	definition.attributes = stringifyPropertyList( definition.attributes );
@@ -222,7 +223,7 @@ function fillElementDefinition( elementDefinition, ranges ) {
 
 	fillElementPositions( elementDefinition, ranges );
 
-	elementDefinition.attributes = getNodeAttributes( element );
+	elementDefinition.attributes = getNodeAttributesForDefinition( element );
 }
 
 function fillElementPositions( elementDefinition, ranges ) {
@@ -322,15 +323,21 @@ function fillTextNodeDefinition( textNodeDefinition ) {
 		}
 	} );
 
-	textNodeDefinition.attributes = getNodeAttributes( textNode );
+	textNodeDefinition.attributes = getNodeAttributesForDefinition( textNode );
 }
 
-function getNodeAttributes( node ) {
-	const attrs = [ ...node.getAttributes() ].map( ( [ name, value ] ) => {
-		return [ name, stringify( value, false ) ];
-	} );
+function getNodeAttributesForDefinition( node ) {
+	const attrs = getSortedNodeAttributes( node )
+		.map( ( [ name, value ] ) => {
+			return [ name, stringify( value, false ) ];
+		} );
 
 	return new Map( attrs );
+}
+
+function getSortedNodeAttributes( node ) {
+	return [ ...node.getAttributes() ]
+		.sort( ( [ nameA ], [ nameB ] ) => nameA < nameB ? -1 : 1 );
 }
 
 function getRangePositionsInElement( node, range ) {

--- a/src/view/data/utils.js
+++ b/src/view/data/utils.js
@@ -114,9 +114,10 @@ export function getEditorViewNodeDefinition( node ) {
 			}
 		}
 
-		for ( const [ name, value ] of node.getAttributes() ) {
-			info.attributes[ name ] = { value };
-		}
+		getSortedNodeAttributes( node )
+			.forEach( ( [ name, value ] ) => {
+				info.attributes[ name ] = { value };
+			} );
 
 		info.properties = {
 			index: {
@@ -225,7 +226,7 @@ function fillElementDefinition( elementDefinition, ranges ) {
 
 	fillViewElementDefinitionPositions( elementDefinition, ranges );
 
-	elementDefinition.attributes = getNodeAttrs( element );
+	elementDefinition.attributes = getNodeAttributesForDefinition( element );
 }
 
 function fillViewTextNodeDefinition( textNodeDefinition, ranges ) {
@@ -344,10 +345,16 @@ function isPathPrefixingAnother( pathA, pathB ) {
 	return false;
 }
 
-function getNodeAttrs( node ) {
-	const attrs = [ ...node.getAttributes() ].map( ( [ name, value ] ) => {
-		return [ name, stringify( value, false ) ];
-	} );
+function getNodeAttributesForDefinition( node ) {
+	const attrs = getSortedNodeAttributes( node )
+		.map( ( [ name, value ] ) => {
+			return [ name, stringify( value, false ) ];
+		} );
 
 	return new Map( attrs );
+}
+
+function getSortedNodeAttributes( node ) {
+	return [ ...node.getAttributes() ]
+		.sort( ( [ nameA ], [ nameB ] ) => nameA.toUpperCase() < nameB.toUpperCase() ? -1 : 1 );
 }


### PR DESCRIPTION
Fix: Node attributes should be sorted in trees and node inspectors (model&view). Closes #97.