### PR TITLE
Allowed the "license-header" ESLint rule. Fixed broken license headers across the project

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,11 @@
 		"ckeditor5",
 		"plugin:react/recommended"
 	],
+	"settings":{
+		"react": {
+			"version": "detect"
+		}
+	},
 	"globals": {
 		"expect": true,
 		"sinon": true,
@@ -23,6 +28,14 @@
 			"error",
 			140
 		],
-		"no-trailing-spaces": "error"
+		"no-trailing-spaces": "error",
+		"ckeditor5-rules/license-header": [ "error", {
+			"headerLines": [
+				"/**",
+				" * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.",
+				" * For licensing, see LICENSE.md.",
+				" */"
+			]
+		} ]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "changelog": "node ./scripts/changelog.js",
     "release:bump-version": "node ./scripts/bump-version.js",
     "release:publish": "node ./scripts/publish.js",
-    "test": "node ./scripts/test.js"
+    "test": "node ./scripts/test.js",
+    "lint": "eslint --quiet \"**/*.js\""
   },
   "repository": {
     "type": "git",
@@ -50,7 +51,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "eslint": "^7.32.0",
-    "eslint-config-ckeditor5": "^3.1.1",
+    "eslint-config-ckeditor5": "^4.0.0",
     "eslint-plugin-react": "^7.27.1",
     "husky": "^4.2.5",
     "istanbul-instrumenter-loader": "^3.0.1",

--- a/src/components/seteditordatabutton.js
+++ b/src/components/seteditordatabutton.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md.
  */
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global console */
-
 export default class Logger {
 	static group( ...args ) {
 		console.group( ...args );

--- a/src/view/data/utils.js
+++ b/src/view/data/utils.js
@@ -221,7 +221,7 @@ function fillElementDefinition( elementDefinition, ranges ) {
 	}
 
 	for ( const child of element.getChildren() ) {
-		elementDefinition.children.push( getViewNodeDefinition( child, ranges, ) );
+		elementDefinition.children.push( getViewNodeDefinition( child, ranges ) );
 	}
 
 	fillViewElementDefinitionPositions( elementDefinition, ranges );

--- a/tests/index.js
+++ b/tests/index.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global require, window */
+/* global window */
 
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/tests/inspector/logger.js
+++ b/tests/inspector/logger.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global console */
-
 import Logger from '../../src/logger';
 
 describe( 'Logger', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3421,18 +3421,18 @@ escodegen@^1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-ckeditor5@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-ckeditor5/-/eslint-config-ckeditor5-3.1.1.tgz#aeb289e858c7103aac09c9bd9347a60db62eedbc"
-  integrity sha512-fiV+pokuTd8wi9primorw06/XpXfhj7+LopRvuEdzqDumXpP0FUznllrnodogXE4+Mg9qX7tAs6YJeyArqyqQQ==
+eslint-config-ckeditor5@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-ckeditor5/-/eslint-config-ckeditor5-4.0.0.tgz#6a4fc760525a0405532c4d6b095d8a17af3cba58"
+  integrity sha512-PDjWbo/PQ/gEvTGmNnEbLl63H+h0weQQkWV23jVCjvrr2Y5FyrVvQhizF5OqCDb5alSk1+RREUURZGhzMzy8LA==
   dependencies:
-    eslint-plugin-ckeditor5-rules "^1.0.0"
+    eslint-plugin-ckeditor5-rules "^4.0.0"
     eslint-plugin-mocha "^7.0.0"
 
-eslint-plugin-ckeditor5-rules@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ckeditor5-rules/-/eslint-plugin-ckeditor5-rules-1.3.0.tgz#faf1fde859cf79e989f248e8a08e6955c317fdcd"
-  integrity sha512-7TjodWU2BRxbsCrhagRCn+V2Qh1UGmBnldG/jWL6HJgTPrsDYhqiS86aJUYsLR2FLEW6X39czXfI556qeMkCKQ==
+eslint-plugin-ckeditor5-rules@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ckeditor5-rules/-/eslint-plugin-ckeditor5-rules-4.0.0.tgz#79d1fd8235212fe5b534b404ecba9a0f35aa1f92"
+  integrity sha512-zjePsfFahvkytgyWZtWOwaWyhXMUalTTQwXQ4XbX0x000R/4YmZh64ikCSJuW8v6acfvQcbFtCdXn/8+dipYKg==
 
 eslint-plugin-mocha@^7.0.0:
   version "7.0.1"


### PR DESCRIPTION
Internal: Allowed the "license-header" ESLint rule. Fixed broken license headers across the project. See [ckeditor/ckeditor5#11468](https://github.com/ckeditor/ckeditor5/issues/11468).