### PR TITLE
Fix incorrect handling of double quotes in `stringify` function in CKEditor inspector.

### DIFF
--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -68,7 +68,7 @@ export function truncateString( string, length ) {
 // Retain the JSON.stringify() formatting instead of fixing 100 tests across the project :)
 function stringifySingleToDoubleQuotesReplacer( value, indent, stringify ) {
 	if ( typeof value === 'string' ) {
-		return `"${ value.replace( '\'', '"' ) }"`;
+		return `"${ value.replaceAll( '\'', '\\"' ) }"`;
 	}
 
 	return stringify( value );

--- a/tests/inspector/components/utils.js
+++ b/tests/inspector/components/utils.js
@@ -21,6 +21,10 @@ describe( 'Utils', () => {
 			expect( stringify( () => 'foo' ) ).to.equal( 'function() {…}' );
 		} );
 
+		it( 'serializes quotes properly', () => {
+			expect( stringify( '\'foo\'' ) ).to.equal( '"\\"foo\\""' );
+		} );
+
 		it( 'stringifies values (no quotes around text)', () => {
 			expect( stringify( undefined ) ).to.equal( 'undefined' );
 			expect( stringify( true ) ).to.equal( 'true' );


### PR DESCRIPTION
Fix: Transform all single quotes passed to `stringify` function instead of only the first one.

### Additional information

It looks like handling of `"` characters is broken in `stringifySingleToDoubleQuotesReplacer`, as it produces invalid JS code like this one:

```ts
stringify( `'foo'` ) // `""foo'"`
```

using `replaceAll` changes it to:

```ts
stringify( `'foo'` ) // `""foo""`
```

Which is still wrong because `"` are nested inside `"` character. I changed it to:

```ts
stringify( `'foo'` ) // `"\"foo\""`
```

Which looks better.