### PR TITLE
Use dynamic imports to fix issues in the release process

### DIFF
--- a/scripts/preparepackages.mjs
+++ b/scripts/preparepackages.mjs
@@ -104,8 +104,7 @@ const tasks = new Listr( [
 		task: async () => {
 			return releaseTools.prepareRepository( {
 				outputDirectory: RELEASE_DIRECTORY,
-				// `cwd` points to the repository root directory.
-				rootPackageJson: preparePackageJson()
+				rootPackageJson: await preparePackageJson()
 			} );
 		}
 	},

--- a/scripts/utils/preparepackagejson.mjs
+++ b/scripts/utils/preparepackagejson.mjs
@@ -3,9 +3,9 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import packageJson from '../../package.json' with { type: 'json' };
+export async function preparePackageJson() {
+	const { default: packageJson } = await import( '../../package.json', { with: { type: 'json' } } );
 
-export function preparePackageJson() {
 	if ( packageJson.engines ) {
 		delete packageJson.engines;
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Use dynamic imports to fix issues in the release process. Closes #208.

---

### Additional information

**Testing steps**

* I modified the latest changelog version (patch bump).
* `rm -rf release/; yarn release:prepare-packages --branch i/208; cat release/ckeditor5-inspector/package.json | grep version`
	```
	yarn run v1.22.19
	$ node ./scripts/preparepackages.mjs --branch i/208
	✔ Verifying the repository.
	✔ Check the release directory.
	✔ Running build command.
	✔ Updating the `#version` field.
	✔ Creating the `ckeditor5-inspector` package in the release directory.
	✔ Cleaning-up.
	✔ Commit & tag.
	Done in 5.48s.
	  "version": "4.1.1",
	```

To clean-up:

```
git tag -d v4.1.1
git reset --hard HEAD~1
```
