### PR TITLE
Reduce resource class for the `notify_ci_failure` job to `small`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
   notify_ci_failure:
     docker:
       - image: cimg/node:24.11.0
+    resource_class: small
     parameters:
       hideAuthor:
         type: string


### PR DESCRIPTION
### 🚀 Summary

As in the title, nothing more to add.

---

### 📌 Related issues

* See: https://github.com/ckeditor/ckeditor5-internal/issues/4292.