### PR TITLE
Add `container` option to attach() for mounting in multi-document environments

### DIFF
--- a/.changelog/20260522101639_container_option.md
+++ b/.changelog/20260522101639_container_option.md
@@ -1,0 +1,12 @@
+ ---
+ type: Fix
+ see:
+   - ckeditor/ckeditor5-inspector#39
+   - ckeditor/ckeditor5-inspector#100
+ communityCredits:
+   - marco-ms
+ ---
+ 
+ Added a `container` option to `CKEditorInspector.attach()` allowing the inspector to be mounted into a custom DOM element instead of `document.body`. 
+ Useful in multi-window environments (Electron, WebView2, iframes) where the global `document` is not the document where the editor lives. 
+ The wrapper element is created in `container.ownerDocument` so ReactDOM event delegation works in the target document.

--- a/.changelog/20260522101639_container_option.md
+++ b/.changelog/20260522101639_container_option.md
@@ -1,12 +1,12 @@
- ---
- type: Fix
- see:
-   - ckeditor/ckeditor5-inspector#39
-   - ckeditor/ckeditor5-inspector#100
- communityCredits:
-   - marco-ms
- ---
- 
- Added a `container` option to `CKEditorInspector.attach()` allowing the inspector to be mounted into a custom DOM element instead of `document.body`. 
- Useful in multi-window environments (Electron, WebView2, iframes) where the global `document` is not the document where the editor lives. 
- The wrapper element is created in `container.ownerDocument` so ReactDOM event delegation works in the target document.
+---
+type: Fix
+see:
+  - ckeditor/ckeditor5-inspector#39
+  - ckeditor/ckeditor5-inspector#100
+communityCredits:
+  - marco-ms
+---
+
+Added a `container` option to `CKEditorInspector.attach()` allowing the inspector to be mounted into a custom DOM element instead of `document.body`. 
+Useful in multi-window environments (Electron, WebView2, iframes) where the global `document` is not the document where the editor lives. 
+The wrapper element is created in `container.ownerDocument` so ReactDOM event delegation works in the target document.

--- a/README.md
+++ b/README.md
@@ -110,17 +110,26 @@ CKEditorInspector.attach( { 'editor-name': editor }, {
 } );
 ```
 
-#### container
+#### `container`
 
-To mount the inspector into a specific DOM element instead of the default document.body, use the options.container option.
+To mount the inspector into a specific DOM element instead of the default `document.body`, use the `options.container` option.
 
-This is useful in multi-window / multi-document environments (Electron, WebView2, iframes) where the global document of the realm that loaded the inspector script is not the document where the editor lives. Without this option, the inspector would be appended to the wrong document's <body> and remain invisible.
+This is useful in multi-window / multi-document environments (Electron, WebView2, iframes) where the global document of the realm that loaded the inspector script is not the document where the editor lives. Without this option, the inspector would be appended to the wrong document's `<body>` and remain invisible.
 
-The inspector wrapper element is created in container.ownerDocument, so ReactDOM event delegation works correctly in the target document.
+The inspector wrapper element is created in `container.ownerDocument`, so ReactDOM event delegation works correctly in the target document.
 
-Note: This option works when CKEditorInspector.attach() is called for the first time only.
+**Note**: This option works when `CKEditorInspector.attach()` is called for the first time only.
 
-js +const editorIframe = document.getElementById( 'editor-frame' ); +const editorDocument = editorIframe.contentDocument; + +CKEditorInspector.attach( editor, { +     // Mount the inspector into the iframe document where the editor lives, +       // instead of the default `document.body` of the outer window. +        container: editorDocument.body +} ); +
+```js
+const editorIframe = document.getElementById( 'editor-frame' );
+const editorDocument = editorIframe.contentDocument;
+
+CKEditorInspector.attach( editor, {
+	// Mount the inspector into the iframe document where the editor lives,
+	// instead of the default `document.body` of the outer window.
+	container: editorDocument.body
+} );
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ CKEditorInspector.attach( { 'editor-name': editor }, {
 } );
 ```
 
+#### container
+
+To mount the inspector into a specific DOM element instead of the default document.body, use the options.container option.
+
+This is useful in multi-window / multi-document environments (Electron, WebView2, iframes) where the global document of the realm that loaded the inspector script is not the document where the editor lives. Without this option, the inspector would be appended to the wrong document's <body> and remain invisible.
+
+The inspector wrapper element is created in container.ownerDocument, so ReactDOM event delegation works correctly in the target document.
+
+Note: This option works when CKEditorInspector.attach() is called for the first time only.
+
+js +const editorIframe = document.getElementById( 'editor-frame' ); +const editorDocument = editorIframe.contentDocument; + +CKEditorInspector.attach( editor, { +     // Mount the inspector into the iframe document where the editor lives, +       // instead of the default `document.body` of the outer window. +        container: editorDocument.body +} ); +
+
 ## Development
 
 > [!NOTE]

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,3 +14,5 @@ minimumReleaseAgeExclude:
 shellEmulator: true
 shamefullyHoist: true
 preferFrozenLockfile: true
+allowBuilds:
+  esbuild: true

--- a/src/ckeditorinspector.jsx
+++ b/src/ckeditorinspector.jsx
@@ -197,12 +197,14 @@ export default class CKEditorInspector {
 			return;
 		}
 
-		const container = CKEditorInspector._wrapper = document.createElement( 'div' );
+		const mountTarget = options.container || document.body;
+		const ownerDocument = mountTarget.ownerDocument || document;
+		const container = CKEditorInspector._wrapper = ownerDocument.createElement( 'div' )
 		let previousEditor;
 		let wasUICollapsed;
 
 		container.className = 'ck-inspector-wrapper';
-		document.body.appendChild( container );
+		mountTarget.appendChild( container );
 
 		// Create a listener that will trigger the store action when the model
 		// is changing or the view is being rendered.

--- a/src/ckeditorinspector.jsx
+++ b/src/ckeditorinspector.jsx
@@ -65,6 +65,17 @@ export default class CKEditorInspector {
 	 *			'footer-editor': editor2
 	 *		}, { option: 'value', ... } );
 	 *
+	 * **Note:** In multi-window / multi-document environments (Electron, WebView2, iframes),
+	 * the inspector can be mounted into a specific container instead of the default `document.body`:
+	 *
+	 *              CKEditorInspector.attach( editor, { container: someElement } );
+	 *
+	 * This is useful when the global `document` of the realm where the inspector module was
+	 * evaluated is not the document where the editor lives — for example, when the editor runs
+	 * inside an iframe but the inspector bundle is loaded in the outer window. The inspector
+	 * wrapper element is created in `container.ownerDocument` so ReactDOM event delegation
+	 * works correctly in the target document.
+	 *
 	 * @param {Editor|Object} editorOrEditors If an editor instance is passed, the inspect will attach to the editor
 	 * with an auto–generated name. It is possible to pass an object with `name: instance` pairs to attach to
 	 * multiple editors at a time with unique names.

--- a/src/ckeditorinspector.jsx
+++ b/src/ckeditorinspector.jsx
@@ -210,7 +210,8 @@ export default class CKEditorInspector {
 
 		const mountTarget = options.container || document.body;
 		const ownerDocument = mountTarget.ownerDocument || document;
-		const container = CKEditorInspector._wrapper = ownerDocument.createElement( 'div' )
+		const container = CKEditorInspector._wrapper = ownerDocument.createElement( 'div' );
+
 		let previousEditor;
 		let wasUICollapsed;
 

--- a/tests/inspector/ckeditorinspector.js
+++ b/tests/inspector/ckeditorinspector.js
@@ -485,6 +485,97 @@ describe( 'CKEditorInspector', () => {
 					expect( getStoreState().ui.isCollapsed ).toBe( false );
 				} );
 			} );
+
+			describe( '#container', () => {
+				let customContainer;
+
+				beforeEach( () => {
+					customContainer = document.createElement( 'div' );
+					document.body.appendChild( customContainer );
+				} );
+
+				afterEach( () => {
+					customContainer.remove();
+				} );
+
+				it( 'should mount the inspector wrapper inside the provided container instead of document.body', () => {
+					CKEditorInspector.attach( editor, { container: customContainer } );
+
+					const wrapper = CKEditorInspector._wrapper;
+
+					expect( wrapper ).toBeInstanceOf( HTMLElement );
+					expect( wrapper.parentNode ).toBe( customContainer );
+					expect( wrapper.parentNode ).not.toBe( document.body );
+				} );
+
+				it( 'should render the inspector UI inside the provided container', () => {
+					CKEditorInspector.attach( editor, { container: customContainer } );
+
+					expect( customContainer.querySelector( '.ck-inspector' ) ).not.toBeNull();
+					expect( CKEditorInspector._wrapper.parentNode ).not.toBe( document.body );
+				} );
+
+				it( 'should create the wrapper element using ownerDocument of the provided container', () => {
+					CKEditorInspector.attach( editor, { container: customContainer } );
+
+					const wrapper = CKEditorInspector._wrapper;
+
+					expect( wrapper.ownerDocument ).toBe( customContainer.ownerDocument );
+				} );
+
+				it( 'should work the same as default when container is document.body', () => {
+					CKEditorInspector.attach( editor, { container: document.body } );
+
+					const wrapper = CKEditorInspector._wrapper;
+
+					expect( wrapper.parentNode ).toBe( document.body );
+					expect( wrapper.firstChild.classList.contains( 'ck-inspector' ) ).toBe( true );
+				} );
+
+				it( 'should not mount a second wrapper when attaching a second editor with a different container', async () => {
+					const anotherContainer = document.createElement( 'div' );
+					document.body.appendChild( anotherContainer );
+
+					CKEditorInspector.attach( editor, { container: customContainer } );
+
+					const firstWrapper = CKEditorInspector._wrapper;
+					const anotherEditor = await TestEditor.create( element );
+
+					CKEditorInspector.attach( anotherEditor, { container: anotherContainer } );
+
+					expect( CKEditorInspector._wrapper ).toBe( firstWrapper );
+					expect( document.querySelectorAll( '.ck-inspector-wrapper' ) ).toHaveLength( 1 );
+
+					anotherContainer.remove();
+
+					await anotherEditor.destroy();
+				} );
+
+				it( 'should still function correctly (attach/detach/destroy) when using a custom container', () => {
+					CKEditorInspector.attach( { foo: editor }, { container: customContainer } );
+
+					let state = getStoreState();
+
+					expect( state.editors.get( 'foo' ) ).toBe( editor );
+
+					CKEditorInspector.detach( 'foo' );
+
+					state = getStoreState();
+
+					expect( state.editors.size ).toBe( 0 );
+
+					CKEditorInspector.destroy();
+
+					expect( CKEditorInspector._wrapper ).toBeNull();
+					expect( customContainer.querySelector( '.ck-inspector-wrapper' ) ).toBeNull();
+				} );
+
+				it( 'should accept the container option passed with named editors', () => {
+					CKEditorInspector.attach( { foo: editor }, { container: customContainer } );
+
+					expect( CKEditorInspector._wrapper.parentNode ).toBe( customContainer );
+				} );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
 ## Suggested merge commit message
 
 Feature: Added a `container` option to `CKEditorInspector.attach()` allowing the inspector to be mounted into a custom DOM element instead of `document.body`. Useful in multi-window environments (Electron, embedded WebViews, iframes) where the global `document` is not the document where the editor lives. See ckeditor/ckeditor5-inspector#39, ckeditor/ckeditor5-inspector#100.
 
 ---
 
 ## Background
 
 `CKEditorInspector.attach()` currently mounts the inspector wrapper unconditionally into the global `document.body` of the realm where the inspector module was evaluated. In single-window setups this is fine, but in multi-document environments the global `document` is often **not** the document where the editor lives:
 
 - **Electron / embedded WebView hosts** — the outer shell loads the inspector bundle, but the editor renders inside a child `BrowserView` / WebView frame.
 - **iframe-isolated apps** — the inspector script is loaded in the parent page but the editor runs in an iframe (or vice-versa).
 - **Tests** — exercising the inspector against a `jsdom` instance other than the bundler's default global.
 
 In all of these, calling `attach()` succeeds (the editor instance gets registered, the "Attached the inspector to a CKEditor 5 instance" log fires), but the user sees no inspector panel — the wrapper was appended to the wrong document's `<body>` and is invisible to the developer.
 
 ## What this PR does
 
 Adds a single new option to the existing `options` argument of `CKEditorInspector.attach()` / `attachToAll()`:
 
 ```js
 CKEditorInspector.attach( editor, {
     container: someElement   // defaults to document.body
 } );

When provided:

 1. The inspector wrapper <div class="ck-inspector-wrapper"> is appended to options.container instead of document.body.
 2. The wrapper is created via container.ownerDocument.createElement(...) instead of the global document.createElement(...), so its ownerDocument matches the target document. This is necessary because ReactDOM's event delegation is rooted at the container's ownerDocument — without it, mounting cross-document would silently break event handling.

When not provided, behavior is identical to current master. No breaking change.

Implementation

Three real lines changed in _mount() in src/ckeditorinspector.jsx:

 const { container: mountTarget = document.body } = options;
 const ownerDocument = mountTarget.ownerDocument || document;
 const container = CKEditorInspector._wrapper = ownerDocument.createElement( 'div' );
 // ...
 mountTarget.appendChild( container );

JSDoc on attach() updated. README gains a new #### container subsection mirroring the existing isCollapsed section. Changelog entry added under .changelog/.

Out of scope

 - Stylesheet injection across documents. The inspector's CSS is imported by the bundler and injected as a <style> tag in the outer document. For most cross-document setups (iframe sharing parent CSSOM, shared preload scripts) this works fine; users with truly isolated documents can clone the <style> themselves. Solving stylesheet injection automatically would be a much bigger change and is best handled in a follow-up if there's demand.
 - attachToAll() discovery scope. attachToAll() discovers editors via document.querySelectorAll('.ck.ck-content...') against the global document. That's a separate problem from where the inspector mounts and is left untouched here.

Related

 - #39 — "Disallow attaching to the same editor twice." Touches the iframe scenario tangentially (duplicate inspector instances when window.editor is set in both windows). Not the same problem but in the same problem space.
 - #100 — Acknowledges the hardcoded <body> placement is awkward. Closed as not_planned. This PR addresses the most actionable subset of that concern: not where on the body, but which document's body.