### PR TITLE
Remove unecessary owner document condition in `container` parameter logic.

### DIFF
--- a/src/ckeditorinspector.jsx
+++ b/src/ckeditorinspector.jsx
@@ -209,8 +209,7 @@ export default class CKEditorInspector {
 		}
 
 		const mountTarget = options.container || document.body;
-		const ownerDocument = mountTarget.ownerDocument || document;
-		const container = CKEditorInspector._wrapper = ownerDocument.createElement( 'div' );
+		const container = CKEditorInspector._wrapper = mountTarget.ownerDocument.createElement( 'div' );
 
 		let previousEditor;
 		let wasUICollapsed;


### PR DESCRIPTION
### 🚀 Summary

Remove unecessary owner document condition in `container` parameter logic.

---

### 📌 Related issues

* Caused by https://github.com/ckeditor/ckeditor5-inspector/pull/255