### PR TITLE
Make container option work in multi-document environments

### DIFF
--- a/.changelog/20260714124544_global_document.md
+++ b/.changelog/20260714124544_global_document.md
@@ -1,0 +1,12 @@
+---
+type: Fix
+closes:
+  - https://github.com/ckeditor/ckeditor5-inspector/issues/39
+  - https://github.com/ckeditor/ckeditor5-inspector/issues/100
+communityCredits:
+  - marco-ms
+---
+
+Fixed the `container` option of `CKEditorInspector.attach()` to actually work in multi-window / multi-document environments (Electron, WebView2, iframes). Previously, even when a container in a different document was passed, the inspector's UI still read and wrote the module-realm `document` and `window` (event listeners, `body` class toggles, viewport sizing, `Modal` app element, `scrollIntoView` targets), so it appeared broken in the host document.
+
+The inspector now derives the host `document` / `window` from `container.ownerDocument` and exposes them via a React `HostContext` consumed by every component that touches the DOM. Inspector-related `<style>` tags are also cloned into the host document's `<head>` so its CSS is available there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,6 @@
 Changelog
 =========
 
-## Unreleased
-
-### Bug fixes
-
-* Fixed the `container` option of `CKEditorInspector.attach()` to actually work in multi-window / multi-document environments (Electron, WebView2, iframes). Previously, even when a container in a different document was passed, the inspector's UI still read and wrote the module-realm `document` and `window` (event listeners, `body` class toggles, viewport sizing, `Modal` app element, `scrollIntoView` targets), so it appeared broken in the host document. See [ckeditor/ckeditor5-inspector#39](https://github.com/ckeditor/ckeditor5-inspector/issues/39), [ckeditor/ckeditor5-inspector#100](https://github.com/ckeditor/ckeditor5-inspector/issues/100).
-
-  The inspector now derives the host `document` / `window` from `container.ownerDocument` and exposes them via a React `HostContext` consumed by every component that touches the DOM. Inspector-related `<style>` tags are also cloned into the host document's `<head>` so its CSS is available there.
-
-  Thanks to [Marco Cimmino (@marco-ms)](https://github.com/marco-ms).
-
-
 ## [5.0.2](https://github.com/ckeditor/ckeditor5-inspector/compare/v5.0.1...v5.0.2) (June 10, 2026)
 
 ### Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+## Unreleased
+
+### Bug fixes
+
+* Fixed the `container` option of `CKEditorInspector.attach()` to actually work in multi-window / multi-document environments (Electron, WebView2, iframes). Previously, even when a container in a different document was passed, the inspector's UI still read and wrote the module-realm `document` and `window` (event listeners, `body` class toggles, viewport sizing, `Modal` app element, `scrollIntoView` targets), so it appeared broken in the host document. See [ckeditor/ckeditor5-inspector#39](https://github.com/ckeditor/ckeditor5-inspector/issues/39), [ckeditor/ckeditor5-inspector#100](https://github.com/ckeditor/ckeditor5-inspector/issues/100).
+
+  The inspector now derives the host `document` / `window` from `container.ownerDocument` and exposes them via a React `HostContext` consumed by every component that touches the DOM. Inspector-related `<style>` tags are also cloned into the host document's `<head>` so its CSS is available there.
+
+  Thanks to [Marco Cimmino (@marco-ms)](https://github.com/marco-ms).
+
+
 ## [5.0.2](https://github.com/ckeditor/ckeditor5-inspector/compare/v5.0.1...v5.0.2) (June 10, 2026)
 
 ### Other changes

--- a/src/ckeditorinspector.jsx
+++ b/src/ckeditorinspector.jsx
@@ -19,6 +19,7 @@ import { updateCommandsState } from './commands/data/actions';
 import EditorListener from './data/utils';
 
 import CKEditorInspectorUI from './ckeditorinspectorui';
+import { HostContext } from './hostcontext';
 import Logger from './logger';
 import {
 	normalizeArguments,
@@ -197,6 +198,11 @@ export default class CKEditorInspector {
 		CKEditorInspector._editorListener = null;
 		CKEditorInspector._wrapper = null;
 		CKEditorInspector._store = null;
+
+		if ( CKEditorInspector._teardown ) {
+			CKEditorInspector._teardown();
+			CKEditorInspector._teardown = null;
+		}
 	}
 
 	static _updateEditorsState() {
@@ -209,13 +215,39 @@ export default class CKEditorInspector {
 		}
 
 		const mountTarget = options.container || document.body;
-		const container = CKEditorInspector._wrapper = mountTarget.ownerDocument.createElement( 'div' );
+		const hostDocument = mountTarget.ownerDocument;
+		const hostWindow = hostDocument.defaultView || window;
+		const container = CKEditorInspector._wrapper = hostDocument.createElement( 'div' );
 
 		let previousEditor;
 		let wasUICollapsed;
 
 		container.className = 'ck-inspector-wrapper';
 		mountTarget.appendChild( container );
+
+		// When the host document differs from the module document (multi-window
+		// scenarios), the inspector CSS injected at import time only lives in
+		// the module document's head. Clone the inspector-related <style> tags
+		// into the host document so the UI renders correctly there too.
+		const clonedStyleElements = [];
+
+		if ( hostDocument !== document ) {
+			for ( const styleEl of document.querySelectorAll( 'style' ) ) {
+				if ( styleEl.textContent && styleEl.textContent.includes( 'ck-inspector' ) ) {
+					const clone = styleEl.cloneNode( true );
+
+					clone.dataset.ckInspectorClone = 'true';
+					hostDocument.head.appendChild( clone );
+					clonedStyleElements.push( clone );
+				}
+			}
+		}
+
+		CKEditorInspector._teardown = () => {
+			for ( const clone of clonedStyleElements ) {
+				clone.remove();
+			}
+		};
 
 		// Create a listener that will trigger the store action when the model
 		// is changing or the view is being rendered.
@@ -306,9 +338,11 @@ export default class CKEditorInspector {
 		} );
 
 		ReactDOM.render(
-			<Provider store={CKEditorInspector._store}>
-				<CKEditorInspectorUI />
-			</Provider>,
+			<HostContext.Provider value={{ document: hostDocument, window: hostWindow }}>
+				<Provider store={CKEditorInspector._store}>
+					<CKEditorInspectorUI />
+				</Provider>
+			</HostContext.Provider>,
 			container
 		);
 	}

--- a/src/ckeditorinspectorui.jsx
+++ b/src/ckeditorinspectorui.jsx
@@ -25,6 +25,7 @@ import SchemaPane from './schema/pane';
 
 import EditorQuickActions from './editorquickactions';
 import ArrowDownIcon from './assets/img/arrow-down.svg';
+import { HostContext } from './hostcontext';
 
 import './ckeditorinspectorui.css';
 
@@ -39,29 +40,37 @@ const INSPECTOR_STYLES = {
 };
 
 class CKEditorInspectorUI extends Component {
+	static contextType = HostContext;
+
 	constructor( props ) {
 		super( props );
 
-		updateBodyHeight( this.props.height );
-		document.body.style.setProperty( '--ck-inspector-collapsed-height', `${ INSPECTOR_COLLAPSED_HEIGHT }px` );
-
 		this.handleInspectorResize = this.handleInspectorResize.bind( this );
+	}
+
+	componentDidMount() {
+		updateBodyHeight( this.context.document, this.props.height );
+		this.context.document.body.style.setProperty(
+			'--ck-inspector-collapsed-height', `${ INSPECTOR_COLLAPSED_HEIGHT }px`
+		);
 	}
 
 	handleInspectorResize( evt, direction, ref ) {
 		const height = ref.style.height;
 
 		this.props.setHeight( height );
-		updateBodyHeight( height );
+		updateBodyHeight( this.context.document, height );
 	}
 
 	render() {
+		const hostBody = this.context.document.body;
+
 		if ( this.props.isCollapsed ) {
-			document.body.classList.remove( 'ck-inspector-body-expanded' );
-			document.body.classList.add( 'ck-inspector-body-collapsed' );
+			hostBody.classList.remove( 'ck-inspector-body-expanded' );
+			hostBody.classList.add( 'ck-inspector-body-collapsed' );
 		} else {
-			document.body.classList.remove( 'ck-inspector-body-collapsed' );
-			document.body.classList.add( 'ck-inspector-body-expanded' );
+			hostBody.classList.remove( 'ck-inspector-body-collapsed' );
+			hostBody.classList.add( 'ck-inspector-body-expanded' );
 		}
 
 		return <Rnd
@@ -102,8 +111,10 @@ class CKEditorInspectorUI extends Component {
 	}
 
 	componentWillUnmount() {
-		document.body.classList.remove( 'ck-inspector-body-expanded' );
-		document.body.classList.remove( 'ck-inspector-body-collapsed' );
+		const hostBody = this.context.document.body;
+
+		hostBody.classList.remove( 'ck-inspector-body-expanded' );
+		hostBody.classList.remove( 'ck-inspector-body-collapsed' );
 	}
 }
 
@@ -126,6 +137,8 @@ export class DocsButton extends Component {
 }
 
 class ToggleButtonVisual extends Component {
+	static contextType = HostContext;
+
 	constructor( props ) {
 		super( props );
 
@@ -146,11 +159,11 @@ class ToggleButtonVisual extends Component {
 	}
 
 	componentDidMount() {
-		window.addEventListener( 'keydown', this.handleShortcut );
+		this.context.window.addEventListener( 'keydown', this.handleShortcut );
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'keydown', this.handleShortcut );
+		this.context.window.removeEventListener( 'keydown', this.handleShortcut );
 	}
 
 	handleShortcut( event ) {
@@ -183,8 +196,8 @@ export const EditorInstanceSelector = connect(
 	{ setCurrentEditorName }
 )( EditorInstanceSelectorVisual );
 
-function updateBodyHeight( height ) {
-	document.body.style.setProperty( '--ck-inspector-height', height );
+function updateBodyHeight( hostDocument, height ) {
+	hostDocument.body.style.setProperty( '--ck-inspector-height', height );
 }
 
 function isToggleShortcut( event ) {

--- a/src/components/seteditordatabutton.jsx
+++ b/src/components/seteditordatabutton.jsx
@@ -8,10 +8,13 @@ import Modal from 'react-modal';
 
 import Button from './button';
 import LoadDataIcon from '../assets/img/load-data.svg';
+import { HostContext } from '../hostcontext';
 
 import './seteditordatabutton.css';
 
 export default class SetEditorDataButton extends Component {
+	static contextType = HostContext;
+
 	constructor( props ) {
 		super( props );
 
@@ -36,7 +39,7 @@ export default class SetEditorDataButton extends Component {
 			/>,
 			<Modal
 				isOpen={this.state.isModalOpen}
-				appElement={document.querySelector( '.ck-inspector-wrapper' )}
+				appElement={this.context.document.querySelector( '.ck-inspector-wrapper' )}
 				onAfterOpen={
 					this._handleModalAfterOpen.bind( this )
 				}

--- a/src/components/sidepane.jsx
+++ b/src/components/sidepane.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import {
 	setSidePaneWidth
 } from '../data/actions';
+import { HostContext } from '../hostcontext';
 
 import './sidepane.css';
 
@@ -18,8 +19,11 @@ const SIDE_PANE_STYLES = {
 };
 
 class SidePane extends Component {
+	static contextType = HostContext;
+
 	get maxSidePaneWidth() {
-		return Math.min( window.innerWidth - 400, window.innerWidth * .8 );
+		const hostWindow = this.context.window;
+		return Math.min( hostWindow.innerWidth - 400, hostWindow.innerWidth * .8 );
 	}
 
 	render() {

--- a/src/editorquickactions.jsx
+++ b/src/editorquickactions.jsx
@@ -16,12 +16,15 @@ import ReadOnlyIcon from './assets/img/read-only.svg';
 import TrashIcon from './assets/img/trash.svg';
 import CopyToClipboardIcon from './assets/img/copy-to-clipboard.svg';
 import CheckmarkIcon from './assets/img/checkmark.svg';
+import { HostContext } from './hostcontext';
 
 import './editorquickactions.css';
 
 const INSPECTOR_READ_ONLY_LOCK_ID = 'Lock from Inspector (@ckeditor/ckeditor5-inspector)';
 
 class EditorQuickActions extends Component {
+	static contextType = HostContext;
+
 	constructor( props ) {
 		super( props );
 
@@ -63,14 +66,14 @@ class EditorQuickActions extends Component {
 	}
 
 	componentDidMount() {
-		document.addEventListener( 'keydown', this._keyDownHandler );
-		document.addEventListener( 'keyup', this._keyUpHandler );
+		this.context.document.addEventListener( 'keydown', this._keyDownHandler );
+		this.context.document.addEventListener( 'keyup', this._keyUpHandler );
 	}
 
 	componentWillUnmount() {
 		// Stop reacting to Shift key press/release after the inspector was destroyed.
-		document.removeEventListener( 'keydown', this._keyDownHandler );
-		document.removeEventListener( 'keyup', this._keyUpHandler );
+		this.context.document.removeEventListener( 'keydown', this._keyDownHandler );
+		this.context.document.removeEventListener( 'keyup', this._keyUpHandler );
 
 		// Don't update the button look after the inspector was destroyed.
 		clearTimeout( this._editorDataJustCopiedTimeout );

--- a/src/hostcontext.js
+++ b/src/hostcontext.js
@@ -1,0 +1,23 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
+ */
+
+import React from 'react';
+
+/**
+ * Host realm (document + window) into which the inspector is mounted.
+ *
+ * The inspector supports being mounted into a document other than the global
+ * `document` of the realm where the module was evaluated (e.g. an Electron
+ * BrowserWindow, a WebView2 popup, or an iframe). All DOM reads/writes made
+ * from the inspector UI must go through this context instead of the module
+ * globals to work correctly in that setup.
+ *
+ * The default value falls back to the module globals so consumers that don't
+ * pass a `container` (single-realm case) continue to work unchanged.
+ */
+export const HostContext = React.createContext( {
+	document: typeof document === 'undefined' ? null : document,
+	window: typeof window === 'undefined' ? null : window
+} );

--- a/src/model/selectioninspector.jsx
+++ b/src/model/selectioninspector.jsx
@@ -15,10 +15,13 @@ import { getModelPositionDefinition } from './utils';
 
 import ConsoleIcon from '../assets/img/console.svg';
 import EyeIcon from '../assets/img/eye.svg';
+import { HostContext } from '../hostcontext';
 
 const API_DOCS_PREFIX = 'https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_model_selection-Selection.html';
 
 class ModelSelectionInspector extends Component {
+	static contextType = HostContext;
+
 	constructor( props ) {
 		super( props );
 
@@ -33,7 +36,7 @@ class ModelSelectionInspector extends Component {
 	}
 
 	handleScrollToSelectionButtonClick() {
-		const domSelectionElement = document.querySelector( '.ck-inspector-tree__position.ck-inspector-tree__position_selection' );
+		const domSelectionElement = this.context.document.querySelector( '.ck-inspector-tree__position.ck-inspector-tree__position_selection' );
 
 		// E.g. wrong root is selected.
 		if ( !domSelectionElement ) {

--- a/src/view/selectioninspector.jsx
+++ b/src/view/selectioninspector.jsx
@@ -15,10 +15,13 @@ import { getViewPositionDefinition } from './utils';
 
 import ConsoleIcon from '../assets/img/console.svg';
 import EyeIcon from '../assets/img/eye.svg';
+import { HostContext } from '../hostcontext';
 
 const API_DOCS_PREFIX = 'https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_view_selection-Selection.html';
 
 class ViewSelectionInspector extends Component {
+	static contextType = HostContext;
+
 	constructor( props ) {
 		super( props );
 
@@ -33,7 +36,7 @@ class ViewSelectionInspector extends Component {
 	}
 
 	handleScrollToSelectionButtonClick() {
-		const domSelectionElement = document.querySelector( '.ck-inspector-tree__position.ck-inspector-tree__position_selection' );
+		const domSelectionElement = this.context.document.querySelector( '.ck-inspector-tree__position.ck-inspector-tree__position_selection' );
 
 		// E.g. wrong root is selected.
 		if ( !domSelectionElement ) {

--- a/tests/inspector/ckeditorinspector.js
+++ b/tests/inspector/ckeditorinspector.js
@@ -576,6 +576,123 @@ describe( 'CKEditorInspector', () => {
 					expect( CKEditorInspector._wrapper.parentNode ).toBe( customContainer );
 				} );
 			} );
+
+			describe( '#container in a cross-document environment', () => {
+				let iframe, hostDocument, hostWindow, hostContainer, outerMarkerStyle;
+
+				beforeEach( () => {
+					// A same-origin iframe gives us a real, distinct document/window pair
+					// that mirrors a multi-window setup (Electron BrowserWindow, WebView2
+					// popup, iframe) — the case the fix is meant to cover.
+					iframe = document.createElement( 'iframe' );
+					document.body.appendChild( iframe );
+
+					hostDocument = iframe.contentDocument;
+					hostWindow = iframe.contentWindow;
+
+					hostContainer = hostDocument.createElement( 'div' );
+					hostDocument.body.appendChild( hostContainer );
+
+					// Simulate an inspector-related <style> tag living in the module
+					// realm (as happens when the bundler injects CSS at import time).
+					// The mount logic is expected to clone it into the host document.
+					outerMarkerStyle = document.createElement( 'style' );
+					outerMarkerStyle.textContent = '.ck-inspector-cross-doc-marker { color: red; }';
+					document.head.appendChild( outerMarkerStyle );
+				} );
+
+				afterEach( () => {
+					outerMarkerStyle.remove();
+					iframe.remove();
+				} );
+
+				it( 'should create the wrapper element in the host document', () => {
+					CKEditorInspector.attach( editor, { container: hostContainer } );
+
+					expect( CKEditorInspector._wrapper.ownerDocument ).toBe( hostDocument );
+					expect( CKEditorInspector._wrapper.ownerDocument ).not.toBe( document );
+				} );
+
+				it( 'should render the inspector UI into the host document only', () => {
+					CKEditorInspector.attach( editor, { container: hostContainer } );
+
+					expect( hostDocument.querySelector( '.ck-inspector' ) ).not.toBeNull();
+					expect( document.body.querySelector( '.ck-inspector' ) ).toBeNull();
+				} );
+
+				it( 'should clone inspector-related <style> tags into the host document <head>', () => {
+					CKEditorInspector.attach( editor, { container: hostContainer } );
+
+					const clones = hostDocument.head.querySelectorAll( 'style[data-ck-inspector-clone="true"]' );
+
+					expect( clones.length ).toBeGreaterThan( 0 );
+
+					const markerClone = [ ...clones ].find( c => c.textContent.includes( '.ck-inspector-cross-doc-marker' ) );
+
+					expect( markerClone ).toBeDefined();
+					expect( markerClone.textContent ).toContain( 'color: red' );
+				} );
+
+				it( 'should not clone <style> tags when the container is in the module document', () => {
+					CKEditorInspector.attach( editor, { container: document.body } );
+
+					const clones = document.head.querySelectorAll( 'style[data-ck-inspector-clone="true"]' );
+
+					expect( clones.length ).toBe( 0 );
+				} );
+
+				it( 'should toggle body classes on the host document, not the module document', () => {
+					CKEditorInspector.attach( editor, { container: hostContainer } );
+
+					const hasHostClass =
+						hostDocument.body.classList.contains( 'ck-inspector-body-expanded' ) ||
+						hostDocument.body.classList.contains( 'ck-inspector-body-collapsed' );
+
+					expect( hasHostClass ).toBe( true );
+					expect( document.body.classList.contains( 'ck-inspector-body-expanded' ) ).toBe( false );
+					expect( document.body.classList.contains( 'ck-inspector-body-collapsed' ) ).toBe( false );
+				} );
+
+				it( 'should bind the Alt+F12 shortcut to the host window', () => {
+					CKEditorInspector.attach( editor, { container: hostContainer } );
+
+					const before = getStoreState().ui.isCollapsed;
+
+					// Dispatch the shortcut on the host window; the outer window
+					// listener (if any lingered) must not receive it.
+					const event = new hostWindow.KeyboardEvent( 'keydown', {
+						key: 'F12',
+						altKey: true,
+						bubbles: true
+					} );
+					hostWindow.dispatchEvent( event );
+
+					expect( getStoreState().ui.isCollapsed ).toBe( !before );
+				} );
+
+				it( 'should remove cloned <style> tags on destroy()', () => {
+					CKEditorInspector.attach( editor, { container: hostContainer } );
+
+					expect(
+						hostDocument.head.querySelectorAll( 'style[data-ck-inspector-clone="true"]' ).length
+					).toBeGreaterThan( 0 );
+
+					CKEditorInspector.destroy();
+
+					expect(
+						hostDocument.head.querySelectorAll( 'style[data-ck-inspector-clone="true"]' ).length
+					).toBe( 0 );
+				} );
+
+				it( 'should clean up host document body classes on destroy()', () => {
+					CKEditorInspector.attach( editor, { container: hostContainer } );
+
+					CKEditorInspector.destroy();
+
+					expect( hostDocument.body.classList.contains( 'ck-inspector-body-expanded' ) ).toBe( false );
+					expect( hostDocument.body.classList.contains( 'ck-inspector-body-collapsed' ) ).toBe( false );
+				} );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
The container option was already accepted by attach() and the wrapper element was created in container.ownerDocument, but the rest of the UI still used the module-realm document/window: body class toggles, viewport sizing, keyboard listeners, react-modal appElement, scrollIntoView targets. When the container lived in a different document (Electron BrowserWindow, WebView2 popup, iframe) the inspector effectively broke.

Introduce a React HostContext carrying { document, window } derived from container.ownerDocument, and route every DOM read/write through it. Also clone inspector-related <style> tags into the host document's <head> so its CSS is available there, and clean them up on destroy().

Closes #39, #100.