### PR TITLE
Update dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^12.1.5",
     "@vitejs/plugin-react": "^6.0.1",
-    "@vitest/browser-playwright": "^4.1.8",
-    "@vitest/coverage-v8": "^4.1.8",
+    "@vitest/browser-playwright": "^4.1.10",
+    "@vitest/coverage-v8": "^4.1.10",
     "ckeditor5": "^47.6.0",
     "eslint": "^10.0.0",
     "eslint-config-ckeditor5": "^19.0.0",
@@ -82,7 +82,7 @@
     "vite": "^8.0.16",
     "vite-plugin-css-injected-by-js": "^4.0.1",
     "vite-plugin-svgr": "^4.4.0",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.10"
   },
   "lint-staged": {
     "**/*": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  diff@^7: ^8.0.3
-  serialize-javascript@^6: ^7.0.5
-  esbuild@^0.27: ^0.28.1
-
 importers:
 
   .:
@@ -46,7 +41,7 @@ importers:
         version: 58.0.0
       '@ckeditor/ckeditor5-dev-changelog':
         specifier: ^58.0.0
-        version: 58.0.0(@types/node@25.5.0)
+        version: 58.0.0(@types/node@25.5.0)(supports-color@7.2.0)
       '@ckeditor/ckeditor5-dev-ci':
         specifier: ^58.0.0
         version: 58.0.0
@@ -55,13 +50,13 @@ importers:
         version: 58.0.0
       '@ckeditor/ckeditor5-dev-release-tools':
         specifier: ^58.0.0
-        version: 58.0.0(@types/node@25.5.0)
+        version: 58.0.0(@types/node@25.5.0)(supports-color@7.2.0)
       '@ckeditor/ckeditor5-dev-utils':
         specifier: ^58.0.0
-        version: 58.0.0
+        version: 58.0.0(supports-color@7.2.0)
       '@eslint-react/eslint-plugin':
         specifier: ^5.17.3
-        version: 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+        version: 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@inquirer/prompts':
         specifier: ^7.8.3
         version: 7.8.6(@types/node@25.5.0)
@@ -73,25 +68,25 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^12.1.5
-        version: 12.1.5(@types/react@19.1.13)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+        version: 12.1.5(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
       '@vitest/browser-playwright':
-        specifier: ^4.1.8
-        version: 4.1.8(playwright@1.58.1)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.8)
+        specifier: ^4.1.10
+        version: 4.1.10(playwright@1.58.1)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/coverage-v8':
-        specifier: ^4.1.8
-        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+        specifier: ^4.1.10
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       ckeditor5:
         specifier: ^47.6.0
-        version: 47.6.0
+        version: 47.6.0(supports-color@7.2.0)
       eslint:
         specifier: ^10.0.0
-        version: 10.7.0(jiti@2.5.1)
+        version: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       eslint-config-ckeditor5:
         specifier: ^19.0.0
-        version: 19.0.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+        version: 19.0.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       eslint-plugin-ckeditor5-rules:
         specifier: ^19.0.0
         version: 19.0.0
@@ -106,7 +101,7 @@ importers:
         version: 9.1.7
       lint-staged:
         specifier: ^10.5.4
-        version: 10.5.4
+        version: 10.5.4(supports-color@7.2.0)
       listr2:
         specifier: ^9.0.2
         version: 9.0.4
@@ -133,10 +128,10 @@ importers:
         version: 4.0.1(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
       vite-plugin-svgr:
         specifier: ^4.4.0
-        version: 4.5.0(rollup@4.59.0)(typescript@5.9.2)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
+        version: 4.5.0(rollup@4.59.0)(supports-color@7.2.0)(typescript@5.9.2)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
       vitest:
-        specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.5.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.5.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
 
 packages:
 
@@ -185,10 +180,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -208,11 +199,6 @@ packages:
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
@@ -1651,6 +1637,9 @@ packages:
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
   '@types/react-dom@17.0.26':
     resolution: {integrity: sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==}
     peerDependencies:
@@ -1659,8 +1648,14 @@ packages:
   '@types/react-redux@7.1.34':
     resolution: {integrity: sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==}
 
+  '@types/react@17.0.93':
+    resolution: {integrity: sha512-KM4Ty/ZTLZupiYxZVAlP+InNJS3De6uBMdq0ePa6/04+eG9Y7ftnWfst1xTLQ5rwAhgHwQ4momt/O4KepdGBTw==}
+
   '@types/react@19.1.13':
     resolution: {integrity: sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==}
+
+  '@types/scheduler@0.16.8':
+    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
 
   '@types/shelljs@0.10.0':
     resolution: {integrity: sha512-OEfyhE5Ox+FeoHbhrEDwm0kXxntO6nsyMRCFvNsIBHPZu5rV1w2OjPcLclaC/IZ1TlzZPgbeMfwAZEi5N238yQ==}
@@ -1747,31 +1742,31 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@vitest/browser-playwright@4.1.8':
-    resolution: {integrity: sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg==}
+  '@vitest/browser-playwright@4.1.10':
+    resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
     peerDependencies:
       playwright: '*'
-      vitest: 4.1.8
+      vitest: 4.1.10
 
-  '@vitest/browser@4.1.8':
-    resolution: {integrity: sha512-u21VzX07HzlJYpFgkxmjEXar/tG2UqWGgyGG/46SrrPc7rSdCTPw5vuowopO9CIqF8UCUQzDFdbVnNpw6N0BfQ==}
+  '@vitest/browser@4.1.10':
+    resolution: {integrity: sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==}
     peerDependencies:
-      vitest: 4.1.8
+      vitest: 4.1.10
 
-  '@vitest/coverage-v8@4.1.8':
-    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
-      '@vitest/browser': 4.1.8
-      vitest: 4.1.8
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.8':
-    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
-  '@vitest/mocker@4.1.8':
-    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1781,20 +1776,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.8':
-    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/runner@4.1.8':
-    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/snapshot@4.1.8':
-    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
-  '@vitest/spy@4.1.8':
-    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
-  '@vitest/utils@4.1.8':
-    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -1910,12 +1905,12 @@ packages:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2099,6 +2094,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
@@ -2726,8 +2724,8 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   is-arguments@1.2.0:
@@ -2887,8 +2885,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdoc-type-pratt-parser@4.1.0:
@@ -3331,8 +3329,8 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3524,8 +3522,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3956,8 +3954,8 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   terser@5.46.0:
@@ -3977,10 +3975,6 @@ packages:
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -4141,7 +4135,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.18
-      esbuild: ^0.28.1
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -4177,20 +4171,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.8:
-    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.8
-      '@vitest/browser-preview': 4.1.8
-      '@vitest/browser-webdriverio': 4.1.8
-      '@vitest/coverage-istanbul': 4.1.8
-      '@vitest/coverage-v8': 4.1.8
-      '@vitest/ui': 4.1.8
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -4328,7 +4322,7 @@ snapshots:
 
   '@11ty/gray-matter@2.1.0':
     dependencies:
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       section-matter: 1.0.0
 
   '@adobe/css-tools@4.4.4': {}
@@ -4347,20 +4341,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4385,23 +4379,21 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -4416,10 +4408,6 @@ snapshots:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/parser@7.29.0':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
@@ -4432,7 +4420,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -4440,14 +4428,14 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@7.29.7':
     dependencies:
@@ -4463,109 +4451,124 @@ snapshots:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-upload': 47.6.0
       ckeditor5: 47.6.0
+
+  '@ckeditor/ckeditor5-adapter-ckfinder@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-upload': 47.6.0
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-alignment@47.6.0':
+  '@ckeditor/ckeditor5-alignment@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-autoformat@47.6.0':
+  '@ckeditor/ckeditor5-autoformat@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-heading': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-autosave@47.6.0':
+  '@ckeditor/ckeditor5-autosave@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-basic-styles@47.6.0':
+  '@ckeditor/ckeditor5-basic-styles@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-block-quote@47.6.0':
+  '@ckeditor/ckeditor5-block-quote@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-enter': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-bookmark@47.6.0':
+  '@ckeditor/ckeditor5-bookmark@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-link': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-link': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-ckbox@47.6.0':
+  '@ckeditor/ckeditor5-ckbox@47.6.0(supports-color@7.2.0)':
     dependencies:
-      '@ckeditor/ckeditor5-cloud-services': 47.6.0
+      '@ckeditor/ckeditor5-cloud-services': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
+      '@ckeditor/ckeditor5-image': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-upload': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       blurhash: 2.0.5
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-ckfinder@47.6.0':
+  '@ckeditor/ckeditor5-ckfinder@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-image': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
   '@ckeditor/ckeditor5-clipboard@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-widget': 47.6.0
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-clipboard@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-widget': 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
@@ -4573,30 +4576,44 @@ snapshots:
   '@ckeditor/ckeditor5-cloud-services@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       ckeditor5: 47.6.0
+
+  '@ckeditor/ckeditor5-cloud-services@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-code-block@47.6.0':
+  '@ckeditor/ckeditor5-code-block@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-clipboard': 47.6.0
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-enter': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
   '@ckeditor/ckeditor5-core@47.6.0':
     dependencies:
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-watchdog': 47.6.0
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-core@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-watchdog': 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
@@ -4605,10 +4622,10 @@ snapshots:
     dependencies:
       glob: 13.0.6
 
-  '@ckeditor/ckeditor5-dev-changelog@58.0.0(@types/node@25.5.0)':
+  '@ckeditor/ckeditor5-dev-changelog@58.0.0(@types/node@25.5.0)(supports-color@7.2.0)':
     dependencies:
       '@11ty/gray-matter': 2.1.0
-      '@ckeditor/ckeditor5-dev-utils': 58.0.0
+      '@ckeditor/ckeditor5-dev-utils': 58.0.0(supports-color@7.2.0)
       cac: 7.0.0
       date-fns: 4.1.0
       glob: 13.0.6
@@ -4630,22 +4647,22 @@ snapshots:
       diff: 8.0.4
       upath: 2.0.1
 
-  '@ckeditor/ckeditor5-dev-release-tools@58.0.0(@types/node@25.5.0)':
+  '@ckeditor/ckeditor5-dev-release-tools@58.0.0(@types/node@25.5.0)(supports-color@7.2.0)':
     dependencies:
-      '@ckeditor/ckeditor5-dev-utils': 58.0.0
+      '@ckeditor/ckeditor5-dev-utils': 58.0.0(supports-color@7.2.0)
       '@octokit/rest': 22.0.1
       cli-columns: 4.0.0
       glob: 13.0.6
       inquirer: 12.11.1(@types/node@25.5.0)
       semver: 7.7.4
       shell-escape: 0.2.0
-      simple-git: 3.36.0
+      simple-git: 3.36.0(supports-color@7.2.0)
       upath: 2.0.1
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
 
-  '@ckeditor/ckeditor5-dev-utils@58.0.0':
+  '@ckeditor/ckeditor5-dev-utils@58.0.0(supports-color@7.2.0)':
     dependencies:
       '@types/shelljs': 0.10.0
       '@types/through2': 2.0.41
@@ -4653,31 +4670,40 @@ snapshots:
       cli-spinners: 3.4.0
       glob: 13.0.6
       is-interactive: 2.0.0
-      pacote: 21.5.0
+      pacote: 21.5.0(supports-color@7.2.0)
       shelljs: 0.10.0
-      simple-git: 3.36.0
+      simple-git: 3.36.0(supports-color@7.2.0)
       through2: 4.0.2
       upath: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-easy-image@47.6.0':
+  '@ckeditor/ckeditor5-easy-image@47.6.0(supports-color@7.2.0)':
     dependencies:
-      '@ckeditor/ckeditor5-cloud-services': 47.6.0
+      '@ckeditor/ckeditor5-cloud-services': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-upload': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
   '@ckeditor/ckeditor5-editor-balloon@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       ckeditor5: 47.6.0
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-editor-balloon@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
@@ -4685,10 +4711,19 @@ snapshots:
   '@ckeditor/ckeditor5-editor-classic@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       ckeditor5: 47.6.0
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-editor-classic@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
@@ -4696,10 +4731,19 @@ snapshots:
   '@ckeditor/ckeditor5-editor-decoupled@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       ckeditor5: 47.6.0
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-editor-decoupled@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
@@ -4707,42 +4751,51 @@ snapshots:
   '@ckeditor/ckeditor5-editor-inline@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       ckeditor5: 47.6.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
-  '@ckeditor/ckeditor5-editor-multi-root@47.6.0':
+  '@ckeditor/ckeditor5-editor-inline@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-emoji@47.6.0':
+  '@ckeditor/ckeditor5-editor-multi-root@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
+      es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-emoji@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-mention': 47.6.0
+      '@ckeditor/ckeditor5-mention': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
       fuzzysort: 3.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-engine@47.6.0':
+  '@ckeditor/ckeditor5-engine@47.6.0(supports-color@7.2.0)':
     dependencies:
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
@@ -4750,21 +4803,27 @@ snapshots:
   '@ckeditor/ckeditor5-enter@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+
+  '@ckeditor/ckeditor5-enter@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-essentials@47.6.0':
+  '@ckeditor/ckeditor5-essentials@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-clipboard': 47.6.0
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-enter': 47.6.0
       '@ckeditor/ckeditor5-select-all': 47.6.0
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-undo': 47.6.0
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4772,56 +4831,65 @@ snapshots:
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       ckeditor5: 47.6.0
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-find-and-replace@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-icons': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-font@47.6.0':
+  '@ckeditor/ckeditor5-font@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-fullscreen@47.6.0':
+  '@ckeditor/ckeditor5-fullscreen@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-classic': 47.6.0
-      '@ckeditor/ckeditor5-editor-decoupled': 47.6.0
+      '@ckeditor/ckeditor5-editor-classic': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-editor-decoupled': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-heading@47.6.0':
+  '@ckeditor/ckeditor5-heading@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
       '@ckeditor/ckeditor5-paragraph': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-highlight@47.6.0':
+  '@ckeditor/ckeditor5-highlight@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4829,120 +4897,129 @@ snapshots:
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-widget': 47.6.0
       ckeditor5: 47.6.0
-    transitivePeerDependencies:
-      - supports-color
 
-  '@ckeditor/ckeditor5-html-embed@47.6.0':
+  '@ckeditor/ckeditor5-horizontal-line@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-html-support@47.6.0':
+  '@ckeditor/ckeditor5-html-embed@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-remove-format': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-icons': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.0(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-html-support@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-enter': 47.6.0
+      '@ckeditor/ckeditor5-heading': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-image': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-list': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-remove-format': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-table': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-widget': 47.6.0
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
   '@ckeditor/ckeditor5-icons@47.6.0': {}
 
-  '@ckeditor/ckeditor5-image@47.6.0':
+  '@ckeditor/ckeditor5-image@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-clipboard': 47.6.0
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-undo': 47.6.0
       '@ckeditor/ckeditor5-upload': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-indent@47.6.0':
+  '@ckeditor/ckeditor5-indent@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-heading': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-list': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-language@47.6.0':
+  '@ckeditor/ckeditor5-language@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-link@47.6.0':
+  '@ckeditor/ckeditor5-link@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-clipboard': 47.6.0
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
+      '@ckeditor/ckeditor5-image': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-list@47.6.0':
+  '@ckeditor/ckeditor5-list@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-clipboard': 47.6.0
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-font': 47.6.0
+      '@ckeditor/ckeditor5-font': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-markdown-gfm@47.6.0':
+  '@ckeditor/ckeditor5-markdown-gfm@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-clipboard': 47.6.0
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@types/hast': 3.0.4
       ckeditor5: 47.6.0
       hast-util-from-dom: 5.0.1
@@ -4953,8 +5030,8 @@ snapshots:
       rehype-dom-stringify: 4.0.2
       rehype-remark: 10.0.1
       remark-breaks: 4.0.0
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
+      remark-gfm: 4.0.1(supports-color@7.2.0)
+      remark-parse: 11.0.0(supports-color@7.2.0)
       remark-rehype: 11.1.2
       remark-stringify: 11.0.0
       unified: 11.0.5
@@ -4962,60 +5039,68 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-media-embed@47.6.0':
+  '@ckeditor/ckeditor5-media-embed@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-clipboard': 47.6.0
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-undo': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-mention@47.6.0':
+  '@ckeditor/ckeditor5-mention@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-minimap@47.6.0':
+  '@ckeditor/ckeditor5-minimap@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-page-break@47.6.0':
+  '@ckeditor/ckeditor5-page-break@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
   '@ckeditor/ckeditor5-paragraph@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+
+  '@ckeditor/ckeditor5-paragraph@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-icons': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5023,8 +5108,15 @@ snapshots:
     dependencies:
       '@ckeditor/ckeditor5-clipboard': 47.6.0
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       ckeditor5: 47.6.0
+
+  '@ckeditor/ckeditor5-paste-from-office@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5032,40 +5124,65 @@ snapshots:
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       ckeditor5: 47.6.0
+
+  '@ckeditor/ckeditor5-remove-format@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-icons': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
   '@ckeditor/ckeditor5-restricted-editing@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       ckeditor5: 47.6.0
+
+  '@ckeditor/ckeditor5-restricted-editing@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-icons': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
   '@ckeditor/ckeditor5-select-all@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+
+  '@ckeditor/ckeditor5-select-all@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-icons': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-show-blocks@47.6.0':
+  '@ckeditor/ckeditor5-show-blocks@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5073,10 +5190,19 @@ snapshots:
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-theme-lark': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       ckeditor5: 47.6.0
+
+  '@ckeditor/ckeditor5-source-editing@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-icons': 47.6.0
+      '@ckeditor/ckeditor5-theme-lark': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5085,62 +5211,78 @@ snapshots:
       '@ckeditor/ckeditor5-core': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       ckeditor5: 47.6.0
+
+  '@ckeditor/ckeditor5-special-characters@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0
+      '@ckeditor/ckeditor5-icons': 47.6.0
+      '@ckeditor/ckeditor5-typing': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-style@47.6.0':
+  '@ckeditor/ckeditor5-style@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-html-support': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
+      '@ckeditor/ckeditor5-html-support': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-list': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-table': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-table@47.6.0':
+  '@ckeditor/ckeditor5-table@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-clipboard': 47.6.0
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-widget': 47.6.0
-      ckeditor5: 47.6.0
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-theme-lark@47.6.0':
+  '@ckeditor/ckeditor5-theme-lark@47.6.0(supports-color@7.2.0)':
     dependencies:
-      '@ckeditor/ckeditor5-ui': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
   '@ckeditor/ckeditor5-typing@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-typing@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-ui@47.6.0':
+  '@ckeditor/ckeditor5-ui@47.6.0(supports-color@7.2.0)':
     dependencies:
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-core': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@types/color-convert': 2.0.4
       color-convert: 3.1.0
       color-parse: 2.0.2
@@ -5152,23 +5294,36 @@ snapshots:
   '@ckeditor/ckeditor5-undo@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+
+  '@ckeditor/ckeditor5-undo@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-icons': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
   '@ckeditor/ckeditor5-upload@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+
+  '@ckeditor/ckeditor5-upload@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-utils@47.6.0':
+  '@ckeditor/ckeditor5-utils@47.6.0(supports-color@7.2.0)':
     dependencies:
-      '@ckeditor/ckeditor5-ui': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
@@ -5176,9 +5331,17 @@ snapshots:
   '@ckeditor/ckeditor5-watchdog@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-watchdog@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
@@ -5186,22 +5349,33 @@ snapshots:
   '@ckeditor/ckeditor5-widget@47.6.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-enter': 47.6.0
       '@ckeditor/ckeditor5-icons': 47.6.0
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      es-toolkit: 1.39.5
+
+  '@ckeditor/ckeditor5-widget@47.6.0(supports-color@7.2.0)':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-enter': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-icons': 47.6.0
+      '@ckeditor/ckeditor5-typing': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
 
-  '@ckeditor/ckeditor5-word-count@47.6.0':
+  '@ckeditor/ckeditor5-word-count@47.6.0(supports-color@7.2.0)':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
-      ckeditor5: 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      ckeditor5: 47.6.0(supports-color@7.2.0)
       es-toolkit: 1.39.5
     transitivePeerDependencies:
       - supports-color
@@ -5308,108 +5482,108 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@10.7.0(jiti@2.5.1))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))':
     dependencies:
-      eslint: 10.7.0(jiti@2.5.1)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.7.0(jiti@2.5.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))':
     dependencies:
-      eslint: 10.7.0(jiti@2.5.1)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint-react/ast@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@eslint-react/ast@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       string-ts: 2.3.1
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/core@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@eslint-react/core@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/var': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/var': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       ts-pattern: 5.9.0
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/eslint-plugin@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@eslint-react/eslint-plugin@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
-      eslint-plugin-react-dom: 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint-plugin-react-jsx: 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint-plugin-react-naming-convention: 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint-plugin-react-rsc: 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint-plugin-react-web-api: 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint-plugin-react-x: 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
+      eslint-plugin-react-dom: 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint-plugin-react-jsx: 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint-plugin-react-naming-convention: 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint-plugin-react-rsc: 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint-plugin-react-web-api: 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint-plugin-react-x: 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/eslint@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@eslint-react/eslint@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/jsx@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@eslint-react/jsx@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/var': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/var': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       ts-pattern: 5.9.0
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/shared@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@eslint-react/shared@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       ts-pattern: 5.9.0
       typescript: 5.9.2
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/var@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@eslint-react/var@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       ts-pattern: 5.9.0
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.5(supports-color@7.2.0)':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.4
     transitivePeerDependencies:
       - supports-color
@@ -5441,18 +5615,18 @@ snapshots:
       '@eslint/css-tree': 4.0.4
       '@eslint/plugin-kit': 0.7.2
 
-  '@eslint/js@10.0.1(eslint@10.7.0(jiti@2.5.1))':
+  '@eslint/js@10.0.1(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))':
     optionalDependencies:
-      eslint: 10.7.0(jiti@2.5.1)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
 
-  '@eslint/markdown@6.6.0':
+  '@eslint/markdown@6.6.0(supports-color@7.2.0)':
     dependencies:
       '@eslint/core': 0.14.0
       '@eslint/plugin-kit': 0.3.5
       github-slugger: 2.0.0
-      mdast-util-from-markdown: 2.0.2
-      mdast-util-frontmatter: 2.0.1
-      mdast-util-gfm: 3.1.0
+      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
+      mdast-util-frontmatter: 2.0.1(supports-color@7.2.0)
+      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
       micromark-extension-frontmatter: 2.0.0
       micromark-extension-gfm: 3.0.0
     transitivePeerDependencies:
@@ -5773,9 +5947,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kwsites/file-exists@1.1.1':
+  '@kwsites/file-exists@1.1.1(supports-color@7.2.0)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5808,23 +5982,23 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@npmcli/agent@3.0.0':
+  '@npmcli/agent@3.0.0(supports-color@7.2.0)':
     dependencies:
       agent-base: 7.1.4
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
       lru-cache: 10.4.3
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@npmcli/agent@4.0.2':
+  '@npmcli/agent@4.0.2(supports-color@7.2.0)':
     dependencies:
       agent-base: 7.1.4
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
       lru-cache: 11.2.1
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5872,12 +6046,12 @@ snapshots:
 
   '@npmcli/redact@4.0.0': {}
 
-  '@npmcli/run-script@10.0.0':
+  '@npmcli/run-script@10.0.0(supports-color@7.2.0)':
     dependencies:
       '@npmcli/node-gyp': 4.0.0
       '@npmcli/package-json': 7.0.1
       '@npmcli/promise-spawn': 8.0.3
-      node-gyp: 11.4.2
+      node-gyp: 11.4.2(supports-color@7.2.0)
       proc-log: 5.0.0
       which: 5.0.0
     transitivePeerDependencies:
@@ -6130,21 +6304,21 @@ snapshots:
 
   '@sigstore/protobuf-specs@0.5.0': {}
 
-  '@sigstore/sign@4.1.1':
+  '@sigstore/sign@4.1.1(supports-color@7.2.0)':
     dependencies:
       '@gar/promise-retry': 1.0.2
       '@sigstore/bundle': 4.0.0
       '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.0
-      make-fetch-happen: 15.0.6
+      make-fetch-happen: 15.0.6(supports-color@7.2.0)
       proc-log: 6.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/tuf@4.0.2':
+  '@sigstore/tuf@4.0.2(supports-color@7.2.0)':
     dependencies:
       '@sigstore/protobuf-specs': 0.5.0
-      tuf-js: 4.1.0
+      tuf-js: 4.1.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6162,10 +6336,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@stylistic/eslint-plugin@4.4.1(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@stylistic/eslint-plugin@4.4.1(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
@@ -6174,54 +6348,54 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.7)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.29.7)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.7)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.7(supports-color@7.2.0))
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.7(supports-color@7.2.0))
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.7(supports-color@7.2.0))
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.7(supports-color@7.2.0))
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.7(supports-color@7.2.0))
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.7(supports-color@7.2.0))
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.7(supports-color@7.2.0))
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.7(supports-color@7.2.0))
 
-  '@svgr/core@8.1.0(typescript@5.9.2)':
+  '@svgr/core@8.1.0(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7(supports-color@7.2.0))
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.2)
       snake-case: 3.0.4
@@ -6234,11 +6408,11 @@ snapshots:
       '@babel/types': 7.29.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.2))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(supports-color@7.2.0)(typescript@5.9.2))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
-      '@svgr/core': 8.1.0(typescript@5.9.2)
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7(supports-color@7.2.0))
+      '@svgr/core': 8.1.0(supports-color@7.2.0)(typescript@5.9.2)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -6264,11 +6438,11 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@12.1.5(@types/react@19.1.13)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
+  '@testing-library/react@12.1.5(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@testing-library/dom': 8.20.1
-      '@types/react-dom': 17.0.26(@types/react@19.1.13)
+      '@types/react-dom': 17.0.26(@types/react@17.0.93)
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
     transitivePeerDependencies:
@@ -6332,9 +6506,11 @@ snapshots:
 
   '@types/parse-json@4.0.2': {}
 
-  '@types/react-dom@17.0.26(@types/react@19.1.13)':
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@17.0.26(@types/react@17.0.93)':
     dependencies:
-      '@types/react': 19.1.13
+      '@types/react': 17.0.93
 
   '@types/react-redux@7.1.34':
     dependencies:
@@ -6343,9 +6519,17 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       redux: 4.2.1
 
+  '@types/react@17.0.93':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      '@types/scheduler': 0.16.8
+      csstype: 3.2.3
+
   '@types/react@19.1.13':
     dependencies:
       csstype: 3.1.3
+
+  '@types/scheduler@0.16.8': {}
 
   '@types/shelljs@0.10.0':
     dependencies:
@@ -6358,15 +6542,15 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2))(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2))(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/type-utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.64.0
-      eslint: 10.7.0(jiti@2.5.1)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.2)
@@ -6374,23 +6558,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@typescript-eslint/parser@8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3
-      eslint: 10.7.0(jiti@2.5.1)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.64.0(typescript@5.9.2)':
+  '@typescript-eslint/project-service@8.64.0(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.64.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -6404,13 +6588,13 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
-  '@typescript-eslint/type-utils@8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      debug: 4.4.3
-      eslint: 10.7.0(jiti@2.5.1)
+      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       ts-api-utils: 2.5.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -6418,13 +6602,13 @@ snapshots:
 
   '@typescript-eslint/types@8.64.0': {}
 
-  '@typescript-eslint/typescript-estree@8.64.0(typescript@5.9.2)':
+  '@typescript-eslint/typescript-estree@8.64.0(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.64.0(typescript@5.9.2)
+      '@typescript-eslint/project-service': 8.64.0(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.17
@@ -6433,13 +6617,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@typescript-eslint/utils@8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -6456,29 +6640,29 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3)
 
-  '@vitest/browser-playwright@4.1.8(playwright@1.58.1)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.8)':
+  '@vitest/browser-playwright@4.1.10(playwright@1.58.1)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.10)':
     dependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.8)
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
+      '@vitest/browser': 4.1.10(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
       playwright: 1.58.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.5.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@25.5.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.8)':
+  '@vitest/browser@4.1.10(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
-      '@vitest/utils': 4.1.8
+      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.5.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@25.5.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -6486,10 +6670,10 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)':
+  '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.8
+      '@vitest/utils': 4.1.10
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -6498,48 +6682,48 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.5.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@25.5.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.8)
+      '@vitest/browser': 4.1.10(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.10)
 
-  '@vitest/expect@4.1.8':
+  '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.10(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 4.1.8
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.1.8':
+  '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.8':
+  '@vitest/runner@4.1.10':
     dependencies:
-      '@vitest/utils': 4.1.8
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.8':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.8': {}
+  '@vitest/spy@4.1.10': {}
 
-  '@vitest/utils@4.1.8':
+  '@vitest/utils@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
+      '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -6630,11 +6814,11 @@ snapshots:
 
   boolean@3.2.0: {}
 
-  brace-expansion@2.0.3:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6667,7 +6851,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 7.0.3
       ssri: 12.0.0
-      tar: 7.5.16
+      tar: 7.5.22
       unique-filename: 4.0.0
 
   cacache@20.0.1:
@@ -6729,66 +6913,130 @@ snapshots:
   ckeditor5@47.6.0:
     dependencies:
       '@ckeditor/ckeditor5-adapter-ckfinder': 47.6.0
-      '@ckeditor/ckeditor5-alignment': 47.6.0
-      '@ckeditor/ckeditor5-autoformat': 47.6.0
-      '@ckeditor/ckeditor5-autosave': 47.6.0
-      '@ckeditor/ckeditor5-basic-styles': 47.6.0
-      '@ckeditor/ckeditor5-block-quote': 47.6.0
-      '@ckeditor/ckeditor5-bookmark': 47.6.0
-      '@ckeditor/ckeditor5-ckbox': 47.6.0
-      '@ckeditor/ckeditor5-ckfinder': 47.6.0
+      '@ckeditor/ckeditor5-alignment': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-autoformat': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-autosave': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-basic-styles': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-block-quote': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-bookmark': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ckbox': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ckfinder': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-clipboard': 47.6.0
       '@ckeditor/ckeditor5-cloud-services': 47.6.0
-      '@ckeditor/ckeditor5-code-block': 47.6.0
-      '@ckeditor/ckeditor5-core': 47.6.0
-      '@ckeditor/ckeditor5-easy-image': 47.6.0
+      '@ckeditor/ckeditor5-code-block': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-core': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-easy-image': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-editor-balloon': 47.6.0
       '@ckeditor/ckeditor5-editor-classic': 47.6.0
       '@ckeditor/ckeditor5-editor-decoupled': 47.6.0
       '@ckeditor/ckeditor5-editor-inline': 47.6.0
-      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0
-      '@ckeditor/ckeditor5-emoji': 47.6.0
-      '@ckeditor/ckeditor5-engine': 47.6.0
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-emoji': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-enter': 47.6.0
-      '@ckeditor/ckeditor5-essentials': 47.6.0
+      '@ckeditor/ckeditor5-essentials': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-find-and-replace': 47.6.0
-      '@ckeditor/ckeditor5-font': 47.6.0
-      '@ckeditor/ckeditor5-fullscreen': 47.6.0
-      '@ckeditor/ckeditor5-heading': 47.6.0
-      '@ckeditor/ckeditor5-highlight': 47.6.0
+      '@ckeditor/ckeditor5-font': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-fullscreen': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-heading': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-highlight': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-horizontal-line': 47.6.0
-      '@ckeditor/ckeditor5-html-embed': 47.6.0
-      '@ckeditor/ckeditor5-html-support': 47.6.0
+      '@ckeditor/ckeditor5-html-embed': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-html-support': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-icons': 47.6.0
-      '@ckeditor/ckeditor5-image': 47.6.0
-      '@ckeditor/ckeditor5-indent': 47.6.0
-      '@ckeditor/ckeditor5-language': 47.6.0
-      '@ckeditor/ckeditor5-link': 47.6.0
-      '@ckeditor/ckeditor5-list': 47.6.0
-      '@ckeditor/ckeditor5-markdown-gfm': 47.6.0
-      '@ckeditor/ckeditor5-media-embed': 47.6.0
-      '@ckeditor/ckeditor5-mention': 47.6.0
-      '@ckeditor/ckeditor5-minimap': 47.6.0
-      '@ckeditor/ckeditor5-page-break': 47.6.0
+      '@ckeditor/ckeditor5-image': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-indent': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-language': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-link': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-list': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-markdown-gfm': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-media-embed': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-mention': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-minimap': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-page-break': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-paragraph': 47.6.0
       '@ckeditor/ckeditor5-paste-from-office': 47.6.0
       '@ckeditor/ckeditor5-remove-format': 47.6.0
       '@ckeditor/ckeditor5-restricted-editing': 47.6.0
       '@ckeditor/ckeditor5-select-all': 47.6.0
-      '@ckeditor/ckeditor5-show-blocks': 47.6.0
+      '@ckeditor/ckeditor5-show-blocks': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-source-editing': 47.6.0
       '@ckeditor/ckeditor5-special-characters': 47.6.0
-      '@ckeditor/ckeditor5-style': 47.6.0
-      '@ckeditor/ckeditor5-table': 47.6.0
-      '@ckeditor/ckeditor5-theme-lark': 47.6.0
+      '@ckeditor/ckeditor5-style': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-table': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-theme-lark': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-typing': 47.6.0
-      '@ckeditor/ckeditor5-ui': 47.6.0
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-undo': 47.6.0
       '@ckeditor/ckeditor5-upload': 47.6.0
-      '@ckeditor/ckeditor5-utils': 47.6.0
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-watchdog': 47.6.0
       '@ckeditor/ckeditor5-widget': 47.6.0
-      '@ckeditor/ckeditor5-word-count': 47.6.0
+      '@ckeditor/ckeditor5-word-count': 47.6.0(supports-color@7.2.0)
+
+  ckeditor5@47.6.0(supports-color@7.2.0):
+    dependencies:
+      '@ckeditor/ckeditor5-adapter-ckfinder': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-alignment': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-autoformat': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-autosave': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-basic-styles': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-block-quote': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-bookmark': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ckbox': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ckfinder': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-clipboard': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-cloud-services': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-code-block': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-core': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-easy-image': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-editor-balloon': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-editor-classic': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-editor-decoupled': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-editor-inline': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-editor-multi-root': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-emoji': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-engine': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-enter': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-essentials': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-find-and-replace': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-font': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-fullscreen': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-heading': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-highlight': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-horizontal-line': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-html-embed': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-html-support': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-icons': 47.6.0
+      '@ckeditor/ckeditor5-image': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-indent': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-language': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-link': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-list': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-markdown-gfm': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-media-embed': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-mention': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-minimap': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-page-break': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-paragraph': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-paste-from-office': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-remove-format': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-restricted-editing': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-select-all': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-show-blocks': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-source-editing': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-special-characters': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-style': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-table': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-theme-lark': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-typing': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ui': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-undo': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-upload': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-utils': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-watchdog': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-widget': 47.6.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-word-count': 47.6.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6871,7 +7119,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.2):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -6887,11 +7135,15 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  csstype@3.2.3: {}
+
   date-fns@4.1.0: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   decode-named-character-reference@1.2.0:
     dependencies:
@@ -7066,18 +7318,18 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-ckeditor5@19.0.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2):
+  eslint-config-ckeditor5@19.0.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2):
     dependencies:
       '@eslint/css': 1.4.0
-      '@eslint/js': 10.0.1(eslint@10.7.0(jiti@2.5.1))
-      '@eslint/markdown': 6.6.0
-      '@stylistic/eslint-plugin': 4.4.1(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@eslint/js': 10.0.1(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))
+      '@eslint/markdown': 6.6.0(supports-color@7.2.0)
+      '@stylistic/eslint-plugin': 4.4.1(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       eslint-plugin-ckeditor5-rules: 19.0.0
-      eslint-plugin-mocha: 11.1.0(eslint@10.7.0(jiti@2.5.1))
+      eslint-plugin-mocha: 11.1.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))
       globals: 16.4.0
       typescript: 5.9.2
-      typescript-eslint: 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      typescript-eslint: 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -7091,99 +7343,99 @@ snapshots:
       validate-npm-package-name: 6.0.2
       yaml: 2.8.3
 
-  eslint-plugin-mocha@11.1.0(eslint@10.7.0(jiti@2.5.1)):
+  eslint-plugin-mocha@11.1.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0(jiti@2.5.1))
-      eslint: 10.7.0(jiti@2.5.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       globals: 15.15.0
 
-  eslint-plugin-react-dom@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2):
+  eslint-plugin-react-dom@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2):
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/jsx': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/jsx': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       compare-versions: 6.1.1
-      eslint: 10.7.0(jiti@2.5.1)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-jsx@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2):
+  eslint-plugin-react-jsx@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2):
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/core': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/jsx': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/core': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/jsx': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-naming-convention@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2):
+  eslint-plugin-react-naming-convention@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2):
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/core': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/var': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/core': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/var': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       ts-pattern: 5.9.0
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-rsc@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2):
+  eslint-plugin-react-rsc@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2):
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/core': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/var': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/core': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/var': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-web-api@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2):
+  eslint-plugin-react-web-api@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2):
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/core': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/var': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/core': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/var': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       birecord: 0.1.2
-      eslint: 10.7.0(jiti@2.5.1)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       ts-pattern: 5.9.0
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-x@5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2):
+  eslint-plugin-react-x@5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2):
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/core': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/jsx': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@eslint-react/var': 5.17.3(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/core': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/jsx': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@eslint-react/var': 5.17.3(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/type-utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
       compare-versions: 6.1.1
-      eslint: 10.7.0(jiti@2.5.1)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       string-ts: 2.3.1
       ts-api-utils: 2.5.0(typescript@5.9.2)
       ts-pattern: 5.9.0
@@ -7204,11 +7456,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.7.0(jiti@2.5.1):
+  eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@10.7.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
+      '@eslint/config-array': 0.23.5(supports-color@7.2.0)
       '@eslint/config-helpers': 0.6.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -7218,7 +7470,7 @@ snapshots:
       '@types/estree': 1.0.8
       ajv: 6.14.0
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -7609,17 +7861,17 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7683,7 +7935,7 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   is-arguments@1.2.0:
     dependencies:
@@ -7820,7 +8072,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -7918,13 +8170,13 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  lint-staged@10.5.4:
+  lint-staged@10.5.4(supports-color@7.2.0):
     dependencies:
       chalk: 4.1.2
       cli-truncate: 2.1.0
       commander: 6.2.1
       cosmiconfig: 7.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       dedent: 0.7.0
       enquirer: 2.4.1
       execa: 4.1.0
@@ -8014,17 +8266,17 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
 
-  make-fetch-happen@14.0.3:
+  make-fetch-happen@14.0.3(supports-color@7.2.0):
     dependencies:
-      '@npmcli/agent': 3.0.0
+      '@npmcli/agent': 3.0.0(supports-color@7.2.0)
       cacache: 19.0.1
       http-cache-semantics: 4.2.0
       minipass: 7.1.3
@@ -8038,10 +8290,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  make-fetch-happen@15.0.6:
+  make-fetch-happen@15.0.6(supports-color@7.2.0):
     dependencies:
       '@gar/promise-retry': 1.0.2
-      '@npmcli/agent': 4.0.2
+      '@npmcli/agent': 4.0.2(supports-color@7.2.0)
       '@npmcli/redact': 4.0.0
       cacache: 20.0.1
       http-cache-semantics: 4.2.0
@@ -8070,14 +8322,14 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
-  mdast-util-from-markdown@2.0.2:
+  mdast-util-from-markdown@2.0.2(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@7.2.0)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -8087,12 +8339,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-frontmatter@2.0.1:
+  mdast-util-frontmatter@2.0.1(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -8106,51 +8358,51 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0:
+  mdast-util-gfm-footnote@2.1.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0:
+  mdast-util-gfm@3.1.0(supports-color@7.2.0):
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-footnote: 2.1.0(supports-color@7.2.0)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-table: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8375,10 +8627,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@7.2.0):
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -8410,11 +8662,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -8470,7 +8722,7 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -8481,16 +8733,16 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
-  node-gyp@11.4.2:
+  node-gyp@11.4.2(supports-color@7.2.0):
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.2
       graceful-fs: 4.2.11
-      make-fetch-happen: 14.0.3
+      make-fetch-happen: 14.0.3(supports-color@7.2.0)
       nopt: 8.1.0
       proc-log: 5.0.0
       semver: 7.7.4
-      tar: 7.5.16
+      tar: 7.5.22
       tinyglobby: 0.2.17
       which: 5.0.0
     transitivePeerDependencies:
@@ -8534,11 +8786,11 @@ snapshots:
       npm-package-arg: 13.0.0
       semver: 7.7.4
 
-  npm-registry-fetch@19.0.0:
+  npm-registry-fetch@19.0.0(supports-color@7.2.0):
     dependencies:
       '@npmcli/redact': 3.2.2
       jsonparse: 1.3.1
-      make-fetch-happen: 15.0.6
+      make-fetch-happen: 15.0.6(supports-color@7.2.0)
       minipass: 7.1.3
       minipass-fetch: 4.0.1
       minizlib: 3.1.0
@@ -8610,25 +8862,25 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  pacote@21.5.0:
+  pacote@21.5.0(supports-color@7.2.0):
     dependencies:
       '@gar/promise-retry': 1.0.2
       '@npmcli/git': 7.0.0
       '@npmcli/installed-package-contents': 4.0.0
       '@npmcli/package-json': 7.0.1
       '@npmcli/promise-spawn': 9.0.1
-      '@npmcli/run-script': 10.0.0
+      '@npmcli/run-script': 10.0.0(supports-color@7.2.0)
       cacache: 20.0.1
       fs-minipass: 3.0.3
       minipass: 7.1.3
       npm-package-arg: 13.0.0
       npm-packlist: 10.0.1
       npm-pick-manifest: 11.0.1
-      npm-registry-fetch: 19.0.0
+      npm-registry-fetch: 19.0.0(supports-color@7.2.0)
       proc-log: 6.1.0
-      sigstore: 4.1.1
+      sigstore: 4.1.1(supports-color@7.2.0)
       ssri: 13.0.1
-      tar: 7.5.16
+      tar: 7.5.22
     transitivePeerDependencies:
       - supports-color
 
@@ -8683,9 +8935,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -8840,21 +9092,21 @@ snapshots:
       mdast-util-newline-to-break: 2.0.0
       unified: 11.0.5
 
-  remark-gfm@4.0.1:
+  remark-gfm@4.0.1(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0
+      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@7.2.0)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9066,24 +9318,24 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sigstore@4.1.1:
+  sigstore@4.1.1(supports-color@7.2.0):
     dependencies:
       '@sigstore/bundle': 4.0.0
       '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.0
-      '@sigstore/sign': 4.1.1
-      '@sigstore/tuf': 4.0.2
+      '@sigstore/sign': 4.1.1(supports-color@7.2.0)
+      '@sigstore/tuf': 4.0.2(supports-color@7.2.0)
       '@sigstore/verify': 3.1.1
     transitivePeerDependencies:
       - supports-color
 
-  simple-git@3.36.0:
+  simple-git@3.36.0(supports-color@7.2.0):
     dependencies:
-      '@kwsites/file-exists': 1.1.1
+      '@kwsites/file-exists': 1.1.1(supports-color@7.2.0)
       '@kwsites/promise-deferred': 1.1.1
       '@simple-git/args-pathspec': 1.0.3
       '@simple-git/argv-parser': 1.1.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9124,17 +9376,17 @@ snapshots:
       '@sentry/node': 7.120.4
       global-agent: 3.0.0
 
-  socks-proxy-agent@8.0.5:
+  socks-proxy-agent@8.0.5(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.4.0
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
@@ -9247,7 +9499,7 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  tar@7.5.16:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -9272,11 +9524,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@1.0.4: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -9309,11 +9556,11 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tuf-js@4.1.0:
+  tuf-js@4.1.0(supports-color@7.2.0):
     dependencies:
       '@tufjs/models': 4.1.0
-      debug: 4.4.3
-      make-fetch-happen: 15.0.6
+      debug: 4.4.3(supports-color@7.2.0)
+      make-fetch-happen: 15.0.6(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9325,13 +9572,13 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  typescript-eslint@8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2):
+  typescript-eslint@8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2))(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1))(typescript@5.9.2)
-      eslint: 10.7.0(jiti@2.5.1)
+      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2))(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.5.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.2)
+      eslint: 10.7.0(jiti@2.5.1)(supports-color@7.2.0)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -9427,11 +9674,11 @@ snapshots:
     dependencies:
       vite: 8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3)
 
-  vite-plugin-svgr@4.5.0(rollup@4.59.0)(typescript@5.9.2)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3)):
+  vite-plugin-svgr@4.5.0(rollup@4.59.0)(supports-color@7.2.0)(typescript@5.9.2)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-      '@svgr/core': 8.1.0(typescript@5.9.2)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))
+      '@svgr/core': 8.1.0(supports-color@7.2.0)(typescript@5.9.2)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@7.2.0)(typescript@5.9.2))(supports-color@7.2.0)
       vite: 8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - rollup
@@ -9442,7 +9689,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.25
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -9453,15 +9700,15 @@ snapshots:
       terser: 5.46.0
       yaml: 2.8.3
 
-  vitest@4.1.8(@types/node@25.5.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3)):
+  vitest@4.1.10(@types/node@25.5.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -9471,14 +9718,14 @@ snapshots:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
-      '@vitest/browser-playwright': 4.1.8(playwright@1.58.1)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.8)
-      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.58.1)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.5.1)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,11 +2,6 @@ allowBuilds:
   esbuild: true
   snyk: true
 
-overrides:
-  'diff@^7': '^8.0.3'
-  'serialize-javascript@^6': '^7.0.5'
-  'esbuild@^0.27': '^0.28.1'
-
 minimumReleaseAge: 4320 # 3 days
 minimumReleaseAgeExclude:
   - '@ckeditor/*'


### PR DESCRIPTION
### 🚀 Summary

Updates dependencies.

---

### 📌 Related issues

* See: https://github.com/ckeditor/ckeditor5-internal/issues/4661

---

### 💡 Additional information

Refreshes the lockfile and aligns the Vitest toolchain (`vitest`, `@vitest/browser-playwright`, `@vitest/coverage-v8`) on `^4.1.10`, bumped together so the workspace stays on a single Vitest version.

Every entry in the `overrides` block turned out to no longer affect resolution, so the block was removed entirely.

`pnpm install --frozen-lockfile` succeeds and the test suite passes (515 tests).